### PR TITLE
fix hyperlinks for the temp docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AI Hub Docs
 
 ## Introduction
-- This is a documentation of various AI tools, mostly <u>[RVC](https://docs.aihub.wtf/essentials/whats-rvc/)</u>-related apps. Made by members of [<u>**AI HUB**</u>](https://discord.gg/aihub).
+- This is a documentation of various AI tools, mostly <u>[RVC](https://docs.ai-hub.wtf/essentials/whats-rvc/)</u>-related apps. Made by members of [<u>**AI HUB**</u>](https://discord.gg/aihub).
 
 - <ins>Topics include</ins>: model training, inference, audio-isolation, datasets, TensorBoard, & more.
 - Both locally and through the cloud.

--- a/assets/Essentials/How To Make AI Cover.md
+++ b/assets/Essentials/How To Make AI Cover.md
@@ -6,7 +6,7 @@ order: 6000
 
 # :icon-unmute: How to Make AI Cover
 
-#### - *Simple AI cover tutorial, using <u>[RVC](https://docs.aihub.wtf/essentials/whats-rvc/)</u>* -
+#### - *Simple AI cover tutorial, using <u>[RVC](https://docs.ai-hub.wtf/essentials/whats-rvc/)</u>* -
 
 ***
 
@@ -16,34 +16,34 @@ order: 6000
 
 - RVC is designed to work with voices only, so to get the best results the sample must be **clean**, with no undesired noises.
 
-- #### <u>[Learn how](https://docs.aihub.wtf/rvc/resources/vocal-isolation/)</u>.
+- #### <u>[Learn how](https://docs.ai-hub.wtf/rvc/resources/vocal-isolation/)</u>.
 ***
 ###### ‎
 ### 2. Get voice model
-- Learn about them & how to search one <u>[here](https://docs.aihub.wtf/essentials/voice-models/)</u>. Be sure to leave credits to the model maker.
+- Learn about them & how to search one <u>[here](https://docs.ai-hub.wtf/essentials/voice-models/)</u>. Be sure to leave credits to the model maker.
 
-- In case the model doesn't exist, click <u>[here](https://docs.aihub.wtf/essentials/how-to-make-voice-models/)</u>.
+- In case the model doesn't exist, click <u>[here](https://docs.ai-hub.wtf/essentials/how-to-make-voice-models/)</u>.
 ***
 ###### ‎
 ### 3. Convert the vocals
-- After obtaining the vocals & model, it's time to set up RVC & do <u>[*inference*](https://docs.aihub.wtf/extra/glossary/#inference)</u>.
+- After obtaining the vocals & model, it's time to set up RVC & do <u>[*inference*](https://docs.ai-hub.wtf/extra/glossary/#inference)</u>.
 
 - There are plenty of versions of RVC, but these are the **best** ones for beginners. Pick according to your needs:
 
     {.list-icon}   
-    - #### :icon-device-desktop: ‎ <u>[Locally](https://docs.aihub.wtf/rvc/local/mainline/)</u>
+    - #### :icon-device-desktop: ‎ <u>[Locally](https://docs.ai-hub.wtf/rvc/local/mainline/)</u>
 
-    - #### :icon-cloud: ‎ <u>[On the cloud](https://docs.aihub.wtf/rvc/cloud/applio-colab/)</u>        
+    - #### :icon-cloud: ‎ <u>[On the cloud](https://docs.ai-hub.wtf/rvc/cloud/applio-colab/)</u>        
 ###### ‎
 !!!warning
-For local users, first ensure you meet the <u>[minimum requirements](https://docs.aihub.wtf/essentials/whats-rvc/#what-are-the-requirements-for-rvc-locally/)</u>.
+For local users, first ensure you meet the <u>[minimum requirements](https://docs.ai-hub.wtf/essentials/whats-rvc/#what-are-the-requirements-for-rvc-locally/)</u>.
 !!!
 ***
 ###### ‎
 ### :icon-check: Tips
 - Congratulations, you've made it to the final part. Now it's to mix the song.       
 ‎   
-- You're free to use any <u>[DAW](https://docs.aihub.wtf/extra/glossary/#daw)</u>, but we recommend **FL Studio** or **BandLab**, as they are beginner-friendly. You can start by searching some of their mixing tutorials on YouTube.      
+- You're free to use any <u>[DAW](https://docs.ai-hub.wtf/extra/glossary/#daw)</u>, but we recommend **FL Studio** or **BandLab**, as they are beginner-friendly. You can start by searching some of their mixing tutorials on YouTube.      
 ‎   
 - **Recommendations for the mix:**     
     - Match the volume of the vocals to the same level as the original ones.      
@@ -56,7 +56,7 @@ For local users, first ensure you meet the <u>[minimum requirements](https://doc
 ‎   
 - Regarding what to do with the **backing vocals**, you have 4 options:
     1. Simply leave the original ones in.
-    2. Convert them using <u>[Mangio-Crepe](https://docs.aihub.wtf/rvc/resources/inference-settings/#mangio-crepe)</u> with a higher hop length.
+    2. Convert them using <u>[Mangio-Crepe](https://docs.ai-hub.wtf/rvc/resources/inference-settings/#mangio-crepe)</u> with a higher hop length.
     3. Record yourself singing them & convert the audio with RVC.
     4. Make vocals from scratch using a voice synthesizer (like SynthV) & convert them with RVC.
 ***
@@ -65,7 +65,7 @@ For local users, first ensure you meet the <u>[minimum requirements](https://doc
 :::
 ‎     
 :::content-right
-[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.aihub.wtf/rvc/#contributions)
+[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.ai-hub.wtf/rvc/#contributions)
 :::     
 ‎   
 ***

--- a/assets/Essentials/How To Make Voice Models.md
+++ b/assets/Essentials/How To Make Voice Models.md
@@ -7,7 +7,7 @@ order: 5000
 # :icon-dependabot:  How to Make Voice Models
 
 
-#### - *Simple model training tutorial, using <u>[RVC](https://docs.aihub.wtf/essentials/whats-rvc/)</u>* -
+#### - *Simple model training tutorial, using <u>[RVC](https://docs.ai-hub.wtf/essentials/whats-rvc/)</u>* -
 ***
 ###### ‎ 
 ### 1. Prepare dataset
@@ -15,7 +15,7 @@ order: 5000
 
 - For the best results, having a **clean** dataset is crucial, so take the time to remove any undesired noises.
        
-- #### <u>[Learn how</u>](https://docs.aihub.wtf/rvc/resources/datasets/).
+- #### <u>[Learn how</u>](https://docs.ai-hub.wtf/rvc/resources/datasets/).
 ***
 ###### ‎ 
 ### 2. Set up RVC
@@ -23,17 +23,17 @@ order: 5000
 
 - There are plenty of versions of RVC, but these are the **best** ones for beginners. Pick according to your needs:
 
-    #### :icon-device-desktop: ‎ <u>[Locally](https://docs.aihub.wtf/rvc/local/mainline/)</u>
+    #### :icon-device-desktop: ‎ <u>[Locally](https://docs.ai-hub.wtf/rvc/local/mainline/)</u>
 
-    #### :icon-cloud: ‎ <u>[On the cloud](https://docs.aihub.wtf/rvc/cloud/rvc-disconnected/)</u>
+    #### :icon-cloud: ‎ <u>[On the cloud](https://docs.ai-hub.wtf/rvc/cloud/rvc-disconnected/)</u>
 ###### ‎
 !!!warning
-For local users, first ensure you meet the <u>[minimum requirements](https://docs.aihub.wtf/essentials/whats-rvc/#what-are-the-requirements-for-rvc-locally)</u>.
+For local users, first ensure you meet the <u>[minimum requirements](https://docs.ai-hub.wtf/essentials/whats-rvc/#what-are-the-requirements-for-rvc-locally)</u>.
 !!!
 ***
 ###### ‎ 
 ### 3. Train the model
-- Before you start training, we inform you that the training guides are oriented around using <u>[TensorBoard](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u>. Read about it & install it after setting up RVC.
+- Before you start training, we inform you that the training guides are oriented around using <u>[TensorBoard](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u>. Read about it & install it after setting up RVC.
 
 - Good luck & remember to be patient! As this won't be an instant process.
 
@@ -43,7 +43,7 @@ For local users, first ensure you meet the <u>[minimum requirements](https://doc
 :::
 ‎  
 :::content-right
-[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.aihub.wtf/rvc/#contributions)
+[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.ai-hub.wtf/rvc/#contributions)
 ::: 
 ‎  
 ***

--- a/assets/Essentials/Voice Models.md
+++ b/assets/Essentials/Voice Models.md
@@ -18,7 +18,7 @@ order: 3000
 
 - **In this case**, voice models are models trained to **replicate** a voice, and with AI they apply it to the input audio.
 
-- There are plenty of them uploaded to the internet, made by the public. And the best way to make them is with <u>[RVC</u>](https://docs.aihub.wtf/essentials/how-to-make-voice-models/)</u>.   
+- There are plenty of them uploaded to the internet, made by the public. And the best way to make them is with <u>[RVC</u>](https://docs.ai-hub.wtf/essentials/how-to-make-voice-models/)</u>.   
 
 ###### ‎   
 ### Voice Model Files 
@@ -32,7 +32,7 @@ order: 3000
 ##### :icon-triangle-down: <u>PTH:</u>
 - This file is the model itself.
 - Contains data regarding pitch.     
-- While training, RVC generates other .PTHs named `D_` and `G_`, but these are the <u>[checkpoints](https://docs.aihub.wtf/extra/glossary/#checkpoints)</u>, not usable models.  
+- While training, RVC generates other .PTHs named `D_` and `G_`, but these are the <u>[checkpoints](https://docs.ai-hub.wtf/extra/glossary/#checkpoints)</u>, not usable models.  
 ***
 !!!warning *Be sure to upload the correct files mentioned before.*
 As people sometimes upload them incorrectly.
@@ -83,7 +83,7 @@ If you get models from different years, remember, the person's voice changes ove
     <img src="../searchrvcmodels-img/3.png" alt="image" width="400" height="auto">
 
 !!!success
-If you're curious about the epochs, <u>[learn more here](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/)</u>.
+If you're curious about the epochs, <u>[learn more here](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/)</u>.
 !!!
 ***
 ###### ‎
@@ -94,7 +94,7 @@ If you're curious about the epochs, <u>[learn more here](https://docs.aihub.wtf/
 ‎   
 - If you need a link for it, use the other methods.     
 
-- If it only exists in weights.gg, download the .ZIP & <u>[upload it to HF](https://docs.aihub.wtf/essentials/voice-models/#uploading-to-hugging-face)</u>.  
+- If it only exists in weights.gg, download the .ZIP & <u>[upload it to HF](https://docs.ai-hub.wtf/essentials/voice-models/#uploading-to-hugging-face)</u>.  
 
 +++ applio.org   
 :::content-center  
@@ -128,7 +128,7 @@ If you get models from different years, remember, the person's voice changes ove
     <img src="../searchrvcmodels-img/applio-web-3.png" alt="image" width="1000" height="auto">
 
 !!!success
-If you're curious about the epochs, <u>[you can learn more here](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/)</u>.
+If you're curious about the epochs, <u>[you can learn more here](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/)</u>.
 !!!
 ***
 ###### ‎
@@ -233,14 +233,14 @@ If you're curious about the epochs, <u>[you can learn more here](https://docs.ai
 ###### ‎   
 
 !!! In case there isn't a .ZIP.
-Download the <u>[correct files](https://docs.aihub.wtf/essentials/voice-models/#voice-model-files)</u> of the model. Then if you need its **link**, <u>[upload it to HF</u>](https://docs.aihub.wtf/essentials/voice-models/#uploading-to-hugging-face).
+Download the <u>[correct files](https://docs.ai-hub.wtf/essentials/voice-models/#voice-model-files)</u> of the model. Then if you need its **link**, <u>[upload it to HF</u>](https://docs.ai-hub.wtf/essentials/voice-models/#uploading-to-hugging-face).
 !!!
 
 +++
 
 ##### ‎ 
 #### If you couldn't find one, you have 3 options:   
-- <u>[Make the model yourself](https://docs.aihub.wtf/essentials/how-to-make-voice-models/)</u>
+- <u>[Make the model yourself](https://docs.ai-hub.wtf/essentials/how-to-make-voice-models/)</u>
 - Pick a different one
 - Comission a **model maker** to make it for you         
 
@@ -253,7 +253,7 @@ Download the <u>[correct files](https://docs.aihub.wtf/essentials/voice-models/#
 :   ‎
 
 #### 1. Zip the model        
-- Select the correct <u>[.PTH & .INDEX](https://docs.aihub.wtf/essentials/voice-models/#voice-model-files)</u> & <u>[zip</u>](https://support.microsoft.com/en-us/windows/zip-and-unzip-files-8d28fa72-f2f9-712f-67df-f80cf89fd4e5) them into a **.ZIP** file.       
+- Select the correct <u>[.PTH & .INDEX](https://docs.ai-hub.wtf/essentials/voice-models/#voice-model-files)</u> & <u>[zip</u>](https://support.microsoft.com/en-us/windows/zip-and-unzip-files-8d28fa72-f2f9-712f-67df-f80cf89fd4e5) them into a **.ZIP** file.       
 
 - Ensure it's .ZIP & not .RAR or .7ZIP.
 
@@ -304,5 +304,5 @@ c. Tap on `Commit changes to main` & the model will begin to upload.
 :::content-center
 #### `You have reached the end.`
 
-[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.aihub.wtf/rvc/#contributions)
+[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.ai-hub.wtf/rvc/#contributions)
 :::

--- a/assets/Essentials/What's RVC.md
+++ b/assets/Essentials/What's RVC.md
@@ -14,7 +14,7 @@ visibility:
 
 - It was designed for desktop, requiring great **specs** to run it effectively, specially **GPU** for training models (specifically **NVIDIA**).
 
-- Though it can be executed through the <u>[cloud](https://docs.aihub.wtf/extra/glossary/#cloud-based)</u> & be used in **any** device, in case you don't meet the previous requirement.        
+- Though it can be executed through the <u>[cloud](https://docs.ai-hub.wtf/extra/glossary/#cloud-based)</u> & be used in **any** device, in case you don't meet the previous requirement.        
 ‎       
 ***
 ## Forks :icon-repo-forked:
@@ -23,7 +23,7 @@ visibility:
 
 - RVC has quite a few forks made by the community, each one meeting different **needs** for the user, and with its pros & cons.     
 
-- These are the main ones, along with their <u>[cloud-based](https://docs.aihub.wtf/extra/glossary/#cloud-based)</u> counterparts:       
+- These are the main ones, along with their <u>[cloud-based](https://docs.ai-hub.wtf/extra/glossary/#cloud-based)</u> counterparts:       
 
     {.list-icon}
     - #### :icon-chevron-right: <u>[Mainline](https://github.com/RVC-Project/Retrieval-based-Voice-Conversion-WebUI)</u> (Original RVC)
@@ -50,12 +50,12 @@ visibility:
 ==- *What's the best fork?*
 ###### ‎       
 - As explained before, it depends on your needs. It's best to try them yourself.
-- For **local** users, <u>[Mainline](https://docs.aihub.wtf/rvc/local/mainline/)</u> is a great starting point. For **cloud** users, the <u>[Applio Colab](https://docs.aihub.wtf/rvc/cloud/applio-colab/)</u>.
+- For **local** users, <u>[Mainline](https://docs.ai-hub.wtf/rvc/local/mainline/)</u> is a great starting point. For **cloud** users, the <u>[Applio Colab](https://docs.ai-hub.wtf/rvc/cloud/applio-colab/)</u>.
 ===
 
 ==- *What are the requirements for RVC locally?*
 ###### ‎      
-> The minimum specs vary depending if it's for training models or <u>[inference](https://docs.aihub.wtf/extra/glossary/#inference)</u>.
+> The minimum specs vary depending if it's for training models or <u>[inference](https://docs.ai-hub.wtf/extra/glossary/#inference)</u>.
 +++ Training
 **SPEC** | **REQUIREMENT** | 
 :---: | :---: | :---: |
@@ -86,20 +86,20 @@ Storage | 6 GB
 ###### ‎  
 - You can, but it's not recommended, as they aren't compatible with AI software.
 - Therefore RVC will be more prone to errors & rely on your CPU, slowing down the process significantly.
-- So it's more convenient using RVC through the <u>[cloud](https://docs.aihub.wtf/extra/glossary/#cloud-based)</u>.
+- So it's more convenient using RVC through the <u>[cloud](https://docs.ai-hub.wtf/extra/glossary/#cloud-based)</u>.
 === 
 
 ==- *How long does it take to train?*
 ###### ‎      
 - The total time depends on a lot of factors, like dataset length, batch size, pretrains, specs, etc.
 
-- A 10 min <u>[dataset](https://docs.aihub.wtf/rvc/resources/datasets/)</u> with <u>[RMVPE](https://docs.aihub.wtf/rvc/resources/inference-settings/#pitch-extraction-algorithm)</u> may take around 1 to 2 hours.
+- A 10 min <u>[dataset](https://docs.ai-hub.wtf/rvc/resources/datasets/)</u> with <u>[RMVPE](https://docs.ai-hub.wtf/rvc/resources/inference-settings/#pitch-extraction-algorithm)</u> may take around 1 to 2 hours.
 === 
 
 ==- *Can I run it on a Mac?*
 ###### ‎      
 - Yes, on Macs of recent generations.
-- But you can only do <u>[inference](https://docs.aihub.wtf/extra/glossary/#inference)</u> & it's a little unstable.  
+- But you can only do <u>[inference](https://docs.ai-hub.wtf/extra/glossary/#inference)</u> & it's a little unstable.  
 ===
 
 ==- *Do I need internet to use it?*
@@ -113,5 +113,5 @@ Storage | 6 GB
 :::content-center
 #### `You have reached the end.`
 
-[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.aihub.wtf/rvc/#contributions)
+[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.ai-hub.wtf/rvc/#contributions)
 :::

--- a/assets/Extra/Glossary.md
+++ b/assets/Extra/Glossary.md
@@ -58,7 +58,7 @@ order: 3000
 ### :icon-chevron-down:Cloud-based
 - Any software or application that's stored, managed, and available through the provider's virtual servers, and is accessed through a web browser.        
 
-- The opposite of <u>[local running</u>](https://docs.aihub.wtf/extra/glossary/#local-running).       
+- The opposite of <u>[local running</u>](https://docs.ai-hub.wtf/extra/glossary/#local-running).       
 
 ***
 
@@ -124,7 +124,7 @@ order: 3000
 ### :icon-chevron-down:Local running
 - Running locally is a process that involves running apps in your own machine, using its resources.       
 
-- The opposite of <u>[cloud-based](https://docs.aihub.wtf/extra/glossary/#cloud-based)</u>.    
+- The opposite of <u>[cloud-based](https://docs.ai-hub.wtf/extra/glossary/#cloud-based)</u>.    
 
 ***
 
@@ -174,20 +174,20 @@ Converting a lossy audio to a lossless one won't restore the lost quality.
 ***
 ###### ‎       
 ### :icon-chevron-down:Specs
-- It refers to a computer's specifications. Hardware like <u>[GPU</u>](https://docs.aihub.wtf/extra/glossary/#gpu), CPU, RAM, etc.     
+- It refers to a computer's specifications. Hardware like <u>[GPU</u>](https://docs.ai-hub.wtf/extra/glossary/#gpu), CPU, RAM, etc.     
 
 - The performance of the hardware of a computer directly correlates to the performance of all its software.
 
 ***
 ###### ‎       
 ### :icon-chevron-down:0 Shot Training
-- Doing <u>[inference](https://docs.aihub.wtf/rvc/extra/glossary/#inference)</u> on an AI model without explicitly training on it. 
+- Doing <u>[inference](https://docs.ai-hub.wtf/rvc/extra/glossary/#inference)</u> on an AI model without explicitly training on it. 
 
 - It's faster but with less quality, and you won't be able to save the model.
 
 - For example, in TTS you do inference by cloning a voice with an audio, a data it hasn't seen before.
 
-- Different from making a dataset & doing the long training process, based on lots of criteria such as <u>[epochs](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/)</u>. 
+- Different from making a dataset & doing the long training process, based on lots of criteria such as <u>[epochs](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/)</u>. 
 
 - In some cases you can do it on GPU, some in CPU.
 
@@ -196,5 +196,5 @@ Converting a lossy audio to a lossless one won't restore the lost quality.
 :::content-center
 #### `You have reached the end.`
 
-[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.aihub.wtf/rvc/#contributions)
+[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.ai-hub.wtf/rvc/#contributions)
 :::

--- a/assets/Extra/Illusion Diffusion.md
+++ b/assets/Extra/Illusion Diffusion.md
@@ -38,5 +38,5 @@ icon: chevron-right
 :::content-center
 #### `You have reached the end.`
 
-[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.aihub.wtf/rvc/#contributions)
+[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.ai-hub.wtf/rvc/#contributions)
 :::

--- a/assets/Extra/Model Maker Role.md
+++ b/assets/Extra/Model Maker Role.md
@@ -14,8 +14,8 @@ order: 1000
 :::
 ###### ‎
 ||| <u> REQUIREMENTS </u>
-- Model's <u>[**.PTH**](https://docs.aihub.wtf/essentials/voice-models/#voice-model-files)</u> file.        
-- Model's <u>[**.INDEX**](https://docs.aihub.wtf/essentials/voice-models/#voice-model-files)</u> file.      
+- Model's <u>[**.PTH**](https://docs.ai-hub.wtf/essentials/voice-models/#voice-model-files)</u> file.        
+- Model's <u>[**.INDEX**](https://docs.ai-hub.wtf/essentials/voice-models/#voice-model-files)</u> file.      
 - General information about the model.
 - General information about its training process.      
 - A Hugging Face account.     
@@ -33,7 +33,7 @@ order: 1000
 :   ‎
 :::
 #### :icon-chevron-right: It lacks the correct files.
-- The .ZIP file must contain both the **correct** `.INDEX` & `.PTH` file. Learn about them <u>[here](https://docs.aihub.wtf/essentials/voice-models/#voice-model-files)</u>.
+- The .ZIP file must contain both the **correct** `.INDEX` & `.PTH` file. Learn about them <u>[here](https://docs.ai-hub.wtf/essentials/voice-models/#voice-model-files)</u>.
 ***
 ###### ‎ 
 #### :icon-chevron-right: Model is low quality.
@@ -45,12 +45,12 @@ order: 1000
    - Is incapable of hitting certain notes.
    - Has slurred speech.
    - Is unable of pronouncing words correctly in its intended language.
-   - Has <u>[artifacting](https://docs.aihub.wtf/rvc/resources/artifacting/)</u>.
+   - Has <u>[artifacting](https://docs.ai-hub.wtf/rvc/resources/artifacting/)</u>.
 ***
 ###### ‎ 
 #### :icon-chevron-right: An outdated extraction method was used.
 {.list-icon}
-- :icon-check-circle: Only **Crepe, **Mangio-Crepe** & **RMVPE** are allowed. Learn about them <u>[here](https://docs.aihub.wtf/rvc/resources/inference-settings/#pitch-extraction-algorithm)</u>
+- :icon-check-circle: Only **Crepe, **Mangio-Crepe** & **RMVPE** are allowed. Learn about them <u>[here](https://docs.ai-hub.wtf/rvc/resources/inference-settings/#pitch-extraction-algorithm)</u>
 
 - :icon-x-circle: Harvest, Dio, Crepe-Tiny, PM, etc. are obsolete.
 
@@ -83,7 +83,7 @@ order: 1000
 #### Step 2: Upload it.
 - The ZIP must be stored in a Hugging Face **public** repository of `openrail` license.    
 
-- Learn how <u>[here</u>](https://docs.aihub.wtf/essentials/voice-models/#uploading-to-hugging-face).
+- Learn how <u>[here</u>](https://docs.ai-hub.wtf/essentials/voice-models/#uploading-to-hugging-face).
 ***
 ###### ‎
 #### Step 3: Prepare the submission.
@@ -104,10 +104,10 @@ order: 1000
 :     The technology used for its training.
 
 **extraction**
-:     The <u>[extraction method](https://docs.aihub.wtf/rvc/resources/inference-settings/#pitch-extraction-algorithm)</u> you used.
+:     The <u>[extraction method](https://docs.ai-hub.wtf/rvc/resources/inference-settings/#pitch-extraction-algorithm)</u> you used.
 
 **epochs**
-:     Total <u>[epochs](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/)</u> amount.
+:     Total <u>[epochs](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/)</u> amount.
 
 **link**
 :     Its download link from Hugging Face.
@@ -148,5 +148,5 @@ You can attach more samples when you repost the model to ``#voice-models``.
 :::content-center
 #### `You have reached the end.`
 
-[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.aihub.wtf/rvc/#contributions)
+[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.ai-hub.wtf/rvc/#contributions)
 :::

--- a/assets/RVC/Cloud/AICoverGen.md
+++ b/assets/RVC/Cloud/AICoverGen.md
@@ -12,13 +12,13 @@ order: 2000
 :::
 
 
-- The AICoverGen Colabs are a port of the AICoverGen RVC <u>[fork</u>](https://docs.aihub.wtf/essentials/whats-rvc/#forks) to <u>[Google Colab</u>](https://docs.aihub.wtf/extra/glossary/#google-colab).
+- The AICoverGen Colabs are a port of the AICoverGen RVC <u>[fork</u>](https://docs.ai-hub.wtf/essentials/whats-rvc/#forks) to <u>[Google Colab</u>](https://docs.ai-hub.wtf/extra/glossary/#google-colab).
 
 - These are ideal for users who want '***quick & dirty***' AI covers, as the whole process of inputting audio, vocal isolation & song mixing is automated. 
 
-- The pitch control is limiting & inconvenient, so if you want a Colab with more control over it, use <u>[Ilaria RVC](https://docs.aihub.wtf/rvc/cloud/ilaria-rvc/)</u> instead.     
+- The pitch control is limiting & inconvenient, so if you want a Colab with more control over it, use <u>[Ilaria RVC](https://docs.ai-hub.wtf/rvc/cloud/ilaria-rvc/)</u> instead.     
 
-- ##### The two versions of the port are: <u>[AICoverGen NO UI](https://docs.aihub.wtf/rvc/cloud/aicovergen/#aicovergen-no-ui)</u> and <u>[AICoverGen UI](https://docs.aihub.wtf/rvc/cloud/aicovergen/#aicovergen-ui)</u>.
+- ##### The two versions of the port are: <u>[AICoverGen NO UI](https://docs.ai-hub.wtf/rvc/cloud/aicovergen/#aicovergen-no-ui)</u> and <u>[AICoverGen UI](https://docs.ai-hub.wtf/rvc/cloud/aicovergen/#aicovergen-ui)</u>.
                
 ***
 ###### ‎  
@@ -83,7 +83,7 @@ It'll be done when you see a check symbol (✔️) on the corner.
 ###### ‎  
 ### <u>Inference</u> :icon-unmute:
 #### 1. Download model      
-a. Go to **Model Download Function** cell. Paste the <u>[model's link](https://docs.aihub.wtf/essentials/voice-models/#how-to-search-voice-models)</u> in the **url** bar.     
+a. Go to **Model Download Function** cell. Paste the <u>[model's link](https://docs.ai-hub.wtf/essentials/voice-models/#how-to-search-voice-models)</u> in the **url** bar.     
 
 b. In **dir_name** name the model. Don't include spaces/special characters.        
            
@@ -141,7 +141,7 @@ Downloaded models will be saved until the Colab session ends.
 ***     
 ###### ‎   
 #### 4. Modify settings (optional)        
-- Below **RVC_DIRNAME** until **Audio Mixing Options** you'll find the <u>[inference settings</u>](https://docs.aihub.wtf/rvc/resources/inference-settings/).     
+- Below **RVC_DIRNAME** until **Audio Mixing Options** you'll find the <u>[inference settings</u>](https://docs.ai-hub.wtf/rvc/resources/inference-settings/).     
 Tweak them accordingly for better results if you wish.
 
     <img src="../aicovergennoui-img/3.png" alt="image" width="270" height="auto">‎      
@@ -198,7 +198,7 @@ The other audios are the stems. Download them too if you wish.
     <img src="../aicovergennoui-img/10.png" alt="image" width="550" height="auto">‎   
 
 ###### ‎  
-- #### If the voice glitches out, click <u>[here</u>](https://docs.aihub.wtf/rvc/resources/artifacting/).
+- #### If the voice glitches out, click <u>[here</u>](https://docs.ai-hub.wtf/rvc/resources/artifacting/).
 
 
 ***
@@ -212,7 +212,7 @@ The other audios are the stems. Download them too if you wish.
 
 - It's characterized & preferred due to its intuitive UI, ideal for beginners.
 
-- But on the downside, it may be more buggy, so consider using the <u>[NO UI version](https://docs.aihub.wtf/rvc/cloud/aicovergen/#aicovergen-no-ui)</u> if issues arise.     
+- But on the downside, it may be more buggy, so consider using the <u>[NO UI version](https://docs.ai-hub.wtf/rvc/cloud/aicovergen/#aicovergen-no-ui)</u> if issues arise.     
 ‎          
 #### Pros & Cons :icon-tasklist:
 ==- *Learn more*
@@ -277,7 +277,7 @@ The other audios are the stems. Download them too if you wish.
 #### 1. Upload model
 - You can upload it using **its link** or **manually** inputting its files.   
     +++ :icon-link: ‎ Link
-    a. Go to the **Download model** tab & paste the <u>[model link](https://docs.aihub.wtf/essentials/voice-models/#how-to-search-voice-models)</u> in the bar.
+    a. Go to the **Download model** tab & paste the <u>[model link](https://docs.ai-hub.wtf/essentials/voice-models/#how-to-search-voice-models)</u> in the bar.
 
     b. Name it in **Name your model**. Don't introduce spaces/special characters.
 
@@ -314,7 +314,7 @@ The other audios are the stems. Download them too if you wish.
 ***
 ###### ‎  
 #### 4. Modify settings (optional)
-- Unfold **Voice conversion options** to modify the <u>[inference settings](https://docs.aihub.wtf/rvc/resources/inference-settings/)</u> for better results.
+- Unfold **Voice conversion options** to modify the <u>[inference settings](https://docs.ai-hub.wtf/rvc/resources/inference-settings/)</u> for better results.
 
 ***
 ###### ‎  
@@ -343,12 +343,12 @@ The other audios are the stems. Download them too if you wish.
 
     <img src="..\aicovergenui-img\stems.png" alt="image" width="470">‎    
 ‎    
-- #### If the voice glitches out, click <u>[here](https://docs.aihub.wtf/rvc/resources/inference-settings/)</u>.
+- #### If the voice glitches out, click <u>[here](https://docs.ai-hub.wtf/rvc/resources/inference-settings/)</u>.
 
 ***
 ###### ‎
 :::content-center
 #### `You have reached the end.`
 
-[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.aihub.wtf/rvc/#contributions)
+[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.ai-hub.wtf/rvc/#contributions)
 :::

--- a/assets/RVC/Cloud/Applio Colab.md
+++ b/assets/RVC/Cloud/Applio Colab.md
@@ -20,7 +20,7 @@ order: 5000
 
 - Because of its user-friendly experience & active development, it's considered to be one of the best forks.     
 
-- As this cloud version is hosted in <u>[Google Colab](https://docs.aihub.wtf/extra/glossary/#google-colab)</u>, remember that you have a runtime of 4 hours.       
+- As this cloud version is hosted in <u>[Google Colab](https://docs.ai-hub.wtf/extra/glossary/#google-colab)</u>, remember that you have a runtime of 4 hours.       
 ‎         
 #### Pros & Cons :icon-tasklist:
 ==- *Learn more*
@@ -92,13 +92,13 @@ Then log in to your Google account.
 :::content-center
 ## Inference :icon-unmute:   
 !!!success
-Be sure to read the <u>[Troubleshooting](https://docs.aihub.wtf/rvc/cloud/applio-colab/#troubleshooting)</u> chapter if any issue arises.
+Be sure to read the <u>[Troubleshooting](https://docs.ai-hub.wtf/rvc/cloud/applio-colab/#troubleshooting)</u> chapter if any issue arises.
 !!!
 :::
 ###### ‎   
 #### 1. Upload voice model.
 - Go to the **Download** tab.       
-You have two ways of uploading it: through <u>[**its link**](https://docs.aihub.wtf/essentials/voice-models/#how-to-search-voice-models)</u> or **manually** inputting its files.
+You have two ways of uploading it: through <u>[**its link**](https://docs.ai-hub.wtf/essentials/voice-models/#how-to-search-voice-models)</u> or **manually** inputting its files.
 
     +++ Link
     a. Go to the **Download** tab & paste the link in the `Model Link` bar.     
@@ -158,7 +158,7 @@ b. Select the model in the ``Voice Model`` & `Index File` dropdown.
 
 ‎  
 #### 4. Modify settings. (optional)      
--  Unfold `Advanced Settings` if you wish to modify the <u>[inference settings](https://docs.aihub.wtf/rvc/resources/inference-settings/)</u> for better results.
+-  Unfold `Advanced Settings` if you wish to modify the <u>[inference settings](https://docs.ai-hub.wtf/rvc/resources/inference-settings/)</u> for better results.
 
     <img src="..\appliocolab-img/3-advanced.png" alt="image" width="550">‎   
 ***
@@ -215,7 +215,7 @@ iv. Then paste it on the `Dataset Path` bar.
 ###### ‎     
 ##### c. Sampling Rate
 ###### ‎    
-- Select your dataset's sample rate. If you don't know the amount, click <u>[here](https://docs.aihub.wtf/rvc/cloud/applio-colab/#extra)</u>.
+- Select your dataset's sample rate. If you don't know the amount, click <u>[here](https://docs.ai-hub.wtf/rvc/cloud/applio-colab/#extra)</u>.
 
     <img src="..\appliocolab-img\4-samplerate.png" alt="image" width="300">‎  
 
@@ -235,7 +235,7 @@ iv. Then paste it on the `Dataset Path` bar.
 ###### ‎    
 ##### a. Pitch extraction algorithm
 ###### ‎  
-- Select the <u>[algorithm](https://docs.aihub.wtf/rvc/resources/inference-settings/#pitch-extraction-algorithm)</u> you want. Use either ``Crepe`` or ``RMVPE``, as the rest are outdated.
+- Select the <u>[algorithm](https://docs.ai-hub.wtf/rvc/resources/inference-settings/#pitch-extraction-algorithm)</u> you want. Use either ``Crepe`` or ``RMVPE``, as the rest are outdated.
 
     <img src="..\appliocolab-img\4-f0.png" alt="image" width="400">
 
@@ -243,7 +243,7 @@ iv. Then paste it on the `Dataset Path` bar.
 ###### ‎  
 ##### b. Hop Length (optional)
 ###### ‎  
-- If you chose ``Crepe``, you can modify its <u>[hop length](https://docs.aihub.wtf/rvc/resources/inference-settings/#mangio-crepe)</u>.
+- If you chose ``Crepe``, you can modify its <u>[hop length](https://docs.ai-hub.wtf/rvc/resources/inference-settings/#mangio-crepe)</u>.
 
     <img src="..\appliocolab-img\4-hoplength.png" alt="image" width="900">
 
@@ -270,7 +270,7 @@ It'll finish when it says `extracted successfully`.
 ###### ‎  
 ##### b. Save Every Epoch
 ###### ‎  
-- Frequency of the <u>[saving checkpoints](https://docs.aihub.wtf/extra/glossary/#checkpoints)</u>, based on the <u>[epochs](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/)</u>.    
+- Frequency of the <u>[saving checkpoints](https://docs.ai-hub.wtf/extra/glossary/#checkpoints)</u>, based on the <u>[epochs](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/)</u>.    
 ‎   
 - If you are a newbie, simply leave it at `15`.              
 
@@ -282,9 +282,9 @@ It'll finish when it says `extracted successfully`.
 ###### ‎  
 ##### c. Total Epoch
 ###### ‎  
-- Input the total amount of <u>[epochs](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/)</u> (training cycles) for the model.     
+- Input the total amount of <u>[epochs](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/)</u> (training cycles) for the model.     
 ‎   
-- But since we'll use <u>[TensorBoard](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u>, use an arbitrarily large value like `1000`
+- But since we'll use <u>[TensorBoard](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u>, use an arbitrarily large value like `1000`
 
     <img src="..\appliocolab-img\4-epoch.png" alt="image" width="420">‎   
 
@@ -292,7 +292,7 @@ It'll finish when it says `extracted successfully`.
 ###### ‎  
 ##### d. Generate Index
 ###### ‎  
-- Click `Generate Index`. This will create the model's <u>[.INDEX](https://docs.aihub.wtf/essentials/voice-models/#voice-model-files)</u> file.
+- Click `Generate Index`. This will create the model's <u>[.INDEX](https://docs.ai-hub.wtf/essentials/voice-models/#voice-model-files)</u> file.
 ***
 ###### ‎  
 ##### e. Start Training
@@ -309,22 +309,22 @@ ii.  Press `Start Training` below to begin the training process.
 ###### ‎  
 ##### f. Monitor training 
 ###### ‎  
-i. <u>[TB](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u> will be available in the Colab. Remember to monitor it, as well as the cell's logs just in case.             
+i. <u>[TB](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u> will be available in the Colab. Remember to monitor it, as well as the cell's logs just in case.             
 
     The latter will show you errors if they happen, and information about the epochs & checkpoints.   
 ‎  
     <img src="..\appliocolab-img\4-logs.png" alt="image" width="800">‎   
 ‎  
 ‎       
-ii. If after around 2:30 hours of training you don't detect <u>[OT](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/#overtraining)</u> <u>[download the model](https://docs.aihub.wtf/rvc/cloud/applio-colab/#c-get-the-pth)</u> of the lowest point, in case it's already OT, and the <u>[.INDEX](https://docs.aihub.wtf/rvc/cloud/applio-colab/#b-get-the-index)</u>.     
+ii. If after around 2:30 hours of training you don't detect <u>[OT](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/#overtraining)</u> <u>[download the model](https://docs.ai-hub.wtf/rvc/cloud/applio-colab/#c-get-the-pth)</u> of the lowest point, in case it's already OT, and the <u>[.INDEX](https://docs.ai-hub.wtf/rvc/cloud/applio-colab/#b-get-the-index)</u>.     
 ‎    
-iii. Then once your GPU runtime resets, begin the <u>[retraining](https://docs.aihub.wtf/rvc/cloud/applio-colab/#5-resuming)</U> procedure.       
+iii. Then once your GPU runtime resets, begin the <u>[retraining](https://docs.ai-hub.wtf/rvc/cloud/applio-colab/#5-resuming)</U> procedure.       
 ***
 !!!warning While training, you might get disconnected if you:    
 - <u>[Stay AFK](https://docs.google.com/document/d/1Pr-AZndodmWgsbOeuHQU4IrgbatFgYc1ChOq_ZAf_5s/edit?usp=sharing)</u> for a long time.     
 - Disconnect from your Internet.       
 - Don't solve the captchas that (might) pop up occasionally.    
-- Run out of <u>[GPU runtime](https://docs.aihub.wtf/rvc/extra/glossary/#google-colab)</u>. 
+- Run out of <u>[GPU runtime](https://docs.ai-hub.wtf/rvc/extra/glossary/#google-colab)</u>. 
 !!!
 ===
 
@@ -353,7 +353,7 @@ ii. Download the **.INDEX** named ``added_``.
 ###### ‎  
 ##### c. Get the PTH
 ###### ‎  
-i. In said folder you'll also find all the <u>[checkpoints](https://docs.aihub.wtf/extra/glossary/#checkpoints)</u>.         
+i. In said folder you'll also find all the <u>[checkpoints](https://docs.ai-hub.wtf/extra/glossary/#checkpoints)</u>.         
 ‎  
 ii. Select the one **closest** to ***before*** the overtraining point, and move it to the new folder.
 
@@ -368,7 +368,7 @@ ii. Select the one **closest** to ***before*** the overtraining point, and move 
         <img src="../appliocolab-img/4-step.png" alt="image" width="600" height="auto">‎  
     ‎          
     ‎    
-iii. And that's all, have fun with your model. To test it, do a normal <u>[inference</u>](https://docs.aihub.wtf/rvc/local/applio/#inference-) as usual.
+iii. And that's all, have fun with your model. To test it, do a normal <u>[inference</u>](https://docs.ai-hub.wtf/rvc/local/applio/#inference-) as usual.
 
 ===
 
@@ -388,7 +388,7 @@ iii. And that's all, have fun with your model. To test it, do a normal <u>[infer
  ‎  
         <img src="../appliocolab-img/4-autobackup.png" alt="image" width="600" height="auto">   
  ‎  
-4. Begin training again & remember to monitor <u>[TB</u>](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/#tensorboard) as before.  
+4. Begin training again & remember to monitor <u>[TB</u>](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/#tensorboard) as before.  
 ===
 
 ###### ‎  
@@ -400,9 +400,9 @@ iii. And that's all, have fun with your model. To test it, do a normal <u>[infer
 ###### ‎  
 - Applio is also known for having one TTS tool by default, with **plenty** of voices to choose for.
 
-- You can also use it with **RVC models** & apply the <u>[inference settings](https://docs.aihub.wtf/rvc/resources/inference-settings/)</u> if you wish.
+- You can also use it with **RVC models** & apply the <u>[inference settings](https://docs.ai-hub.wtf/rvc/resources/inference-settings/)</u> if you wish.
 
-- Additionally, you can download the **Eleven Labs** TTS <u>[plugin](https://docs.aihub.wtf/rvc/cloud/applio-colab/#plugins)</u>.       
+- Additionally, you can download the **Eleven Labs** TTS <u>[plugin](https://docs.ai-hub.wtf/rvc/cloud/applio-colab/#plugins)</u>.       
 ***
 ###### ‎  
 #### <u>Instructions:</u>
@@ -413,11 +413,11 @@ iii. And that's all, have fun with your model. To test it, do a normal <u>[infer
 ***   
 ###### ‎   
 
-2. If you want to use an RVC model, <u>[download it](https://docs.aihub.wtf/rvc/cloud/applio-colab/#1-upload-voice-model)</u>, go to **TTS**, click `Refresh` & select it in **Voice Model** & **Index File**.
+2. If you want to use an RVC model, <u>[download it](https://docs.ai-hub.wtf/rvc/cloud/applio-colab/#1-upload-voice-model)</u>, go to **TTS**, click `Refresh` & select it in **Voice Model** & **Index File**.
 
    <img src="../appliocolab-img/5-vm.png" alt="image" width="600" height="auto">‎    
 ‎             
-- To modify the <u>[inference settings](https://docs.aihub.wtf/rvc/resources/inference-settings/)</u> or the output folder for the TTS/RVC audio, unfold `Advanced Settings`.
+- To modify the <u>[inference settings](https://docs.ai-hub.wtf/rvc/resources/inference-settings/)</u> or the output folder for the TTS/RVC audio, unfold `Advanced Settings`.
 
 ***
 ###### ‎      
@@ -443,7 +443,7 @@ iii. And that's all, have fun with your model. To test it, do a normal <u>[infer
 ###### ‎  
 - Applio has an **Extra** menu, containing an **audio analyzer**, originally made by <u>[Ilaria](https://ko-fi.com/ilariaowo)</u>.
 
-- Making it convenient for determining the <u>[sample rate](https://docs.aihub.wtf/rvc/resources/datasets/#sample-rate)</u> of datasets when training models.
+- Making it convenient for determining the <u>[sample rate](https://docs.ai-hub.wtf/rvc/resources/datasets/#sample-rate)</u> of datasets when training models.
 
 - It also contains the **model fusion** tool, ideal for advanced users.
 
@@ -525,13 +525,13 @@ If the frequencies don't reach the top of the spectrogram, see at which number p
 ==- *There's no public URL.*
 ###### ‎   
 
-- In case the **public URL** doesn't show up, there might be a problem with <u>[Gradio</u>](https://docs.aihub.wtf/extra/glossary/#gradio)</u>, you can check if it's down <u>[here</u>](https://status.gradio.app/)</u>.
+- In case the **public URL** doesn't show up, there might be a problem with <u>[Gradio</u>](https://docs.ai-hub.wtf/extra/glossary/#gradio)</u>, you can check if it's down <u>[here</u>](https://status.gradio.app/)</u>.
 
 - To fix this, instead of waiting until Gradio is back online, just check the **share_tunnel*** checkbox on the Start Applio cell.
 
     <img src="..\appliocolab-img\2-start-share-tunnel.png" alt="image" width="430">
 ‎ 
-- Applio will use <u>[localtunnel</u>](https://docs.aihub.wtf/extra/glossary/#localtunnel) instead of the Gradio Public Share Link now, copy paste the **Password IP** (Don't worry, it's the Google PC's IP, not yours).
+- Applio will use <u>[localtunnel</u>](https://docs.ai-hub.wtf/extra/glossary/#localtunnel) instead of the Gradio Public Share Link now, copy paste the **Password IP** (Don't worry, it's the Google PC's IP, not yours).
 
 - Then open the **Share Link** given by the colab and paste the "Password IP" in "Tunnel Password", finally click Submit.
 
@@ -552,23 +552,23 @@ If the frequencies don't reach the top of the spectrogram, see at which number p
 
 ==- *The voice glitches out.*
 ###### ‎   
-- This a phenomenon called artifacting. To fix it, read <u>[here](https://docs.aihub.wtf/rvc/resources/artifacting/)</u>.
+- This a phenomenon called artifacting. To fix it, read <u>[here](https://docs.ai-hub.wtf/rvc/resources/artifacting/)</u>.
 
 ===
 
 ==- *Cannot connect to GPU backend.*
 ###### ‎   
-- You have exhausted the <u>[GPU runtime](https://docs.aihub.wtf/rvc/extra/glossary/#google-colab)</u> of Colab.
+- You have exhausted the <u>[GPU runtime](https://docs.ai-hub.wtf/rvc/extra/glossary/#google-colab)</u> of Colab.
 ===
 
 ==- *I couldn't find my answer.*
 ###### ‎   
-- Report your issue <u>[here](https://docs.aihub.wtf/rvc/#contributions)</u>.
+- Report your issue <u>[here](https://docs.ai-hub.wtf/rvc/#contributions)</u>.
 ===
 ***
 ###### ‎
 :::content-center
 #### `You have reached the end.`
 
-[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.aihub.wtf/rvc/#contributions)
+[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.ai-hub.wtf/rvc/#contributions)
 :::

--- a/assets/RVC/Cloud/EasyGUI.md
+++ b/assets/RVC/Cloud/EasyGUI.md
@@ -11,7 +11,7 @@ visibility: private
 ## Introduction
 :::
 
-- The EasyGUI Colab is a port of the custom layout of <u>[Mainline](https://docs.aihub.wtf/rvc/local/mainline/)</u> made by <u>[Rejekts](https://ko-fi.com/rejekts)</u>, named as the Colab.
+- The EasyGUI Colab is a port of the custom layout of <u>[Mainline](https://docs.ai-hub.wtf/rvc/local/mainline/)</u> made by <u>[Rejekts](https://ko-fi.com/rejekts)</u>, named as the Colab.
 
 - Its strongest points are its active maintenance & that it holds the simplicity of Mainline.
 
@@ -28,7 +28,7 @@ visibility: private
 - Feature to save model to HF
 ||| ❌ **CONS** 
 - Has less features    
-- No <u>[Mangio-Crepe</u>](https://docs.aihub.wtf/rvc/resources/inference-settings/#pitch-extraction-algorithm) 
+- No <u>[Mangio-Crepe</u>](https://docs.ai-hub.wtf/rvc/resources/inference-settings/#pitch-extraction-algorithm) 
 - Usage limit for free users
 ||| 
 ===
@@ -91,7 +91,7 @@ b. Then open the **public url**.
 ### Inference 
 
 #### 1. Download model
-a. Go to the **Download Model** tab & paste the <u>[model link](https://docs.aihub.wtf/essentials/voice-models/#how-to-search-voice-models)</u> in the upper bar.
+a. Go to the **Download Model** tab & paste the <u>[model link](https://docs.ai-hub.wtf/essentials/voice-models/#how-to-search-voice-models)</u> in the upper bar.
 
     <img src="..\easygui-img\ui-i-modellink.png" alt="image" width="450">‎      
 ‎   
@@ -120,7 +120,7 @@ b. Once it's done uploading, click `Refresh` again.
 ***
 ###### ‎  
 #### 4. Modify settings (optional)
-- If you wish, modify the [inference settings](https://docs.aihub.wtf/rvc/resources/artifacting/) for better results. Unfold the **General settings** menu to see more.
+- If you wish, modify the [inference settings](https://docs.ai-hub.wtf/rvc/resources/artifacting/) for better results. Unfold the **General settings** menu to see more.
 
 - The **Index Rate** is in the **Auto-detect index path** bar, and **Pitch** is on the right of `Refresh`.
 
@@ -148,7 +148,7 @@ b. First set a name for your model in **Enter the experiment name**.
 ***
 ###### ‎
 #### 2. Target sample rate
-- Select your dataset's <u>[sample rate](https://docs.aihub.wtf/rvc/resources/datasets/#sample-rate)</u>.
+- Select your dataset's <u>[sample rate](https://docs.ai-hub.wtf/rvc/resources/datasets/#sample-rate)</u>.
 
     <img src="..\easygui-img\ui-t-samplerate.png" alt="image" width="300">‎ 
 
@@ -172,16 +172,16 @@ b. Once it's done uploading, press **Process Data**. It'll finish when the logs 
 ***
 ###### ‎    
 #### 5. Total training epochs
-- Input the total amount of <u>[epochs](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/)</u> (training cycles) for the model.
+- Input the total amount of <u>[epochs](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/)</u> (training cycles) for the model.
 
-- But since we'll use <u>[TensorBoard](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u>, use an arbitrarily large value like `1000`
+- But since we'll use <u>[TensorBoard](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u>, use an arbitrarily large value like `1000`
 
     <img src="..\easygui-img\ui-t-epochs.png" alt="image" width="420">‎
 
 ***
 ###### ‎
 #### 6. Save frequency
-- Rate at which the model will be saved, based on the <u>[epochs](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/)</u>. The saved models are known as the "checkpoints".    
+- Rate at which the model will be saved, based on the <u>[epochs](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/)</u>. The saved models are known as the "checkpoints".    
 
 - If you are a newbie, leave it at `15`.  
 
@@ -278,7 +278,7 @@ b. Paste it in the **input_path** & **save_as** bars.
 ***
 ###### ‎
 #### 4. Modify settings (optional)
-- Modify the <u>[inference settings](https://docs.aihub.wtf/rvc/resources/inference-settings/)</u> for better results if you wish.
+- Modify the <u>[inference settings](https://docs.ai-hub.wtf/rvc/resources/inference-settings/)</u> for better results if you wish.
 
 
 ***
@@ -326,7 +326,7 @@ iii. Paste the path in the **dataset_folder** bar. Then run the **STEP 1** cell.
 ###### ‎
 ‎ ‎ ‎ ‎ <img src="..\easygui-img\3-step2.png" alt="image" width="390">‎   
 ‎       
-i. Select the **RMVPE_GPU** <u>[algorithm](https://docs.aihub.wtf/rvc/resources/inference-settings/#pitch-extraction-algorithm)</u>.     
+i. Select the **RMVPE_GPU** <u>[algorithm](https://docs.ai-hub.wtf/rvc/resources/inference-settings/#pitch-extraction-algorithm)</u>.     
     Only use that one, as PM & Harvest are obsolete, and normal RMVPE is slower in this case.     
 ‎   
 ii. Then run the cell.      
@@ -339,7 +339,7 @@ ii. Then run the cell.
 ###### ‎
 ##### a. Train index
 ###### ‎
-i. Run the **STEP 3** to generate the <u>[.INDEX](https://docs.aihub.wtf/essentials/voice-models/#voice-model-files)</u> of the model.
+i. Run the **STEP 3** to generate the <u>[.INDEX](https://docs.ai-hub.wtf/essentials/voice-models/#voice-model-files)</u> of the model.
 
 ii. To download it, open the file explorer & go to RVC, logs, and in your model's folder right-click the INDEX named **added_** & press `Download`.
 
@@ -352,15 +352,15 @@ ii. To download it, open the file explorer & go to RVC, logs, and in your model'
 - The name you assigned the model previously.
 
 ##### b. Save frequency
-- Frequency of the <u>[saving checkpoints](https://docs.aihub.wtf/extra/glossary/#checkpoints)</u>, based on the <u>[epochs](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/)</u>.   
+- Frequency of the <u>[saving checkpoints](https://docs.ai-hub.wtf/extra/glossary/#checkpoints)</u>, based on the <u>[epochs](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/)</u>.   
 
 - If you are a newbie, simply leave it at `15`.        
 
 - E.g: with a value of ``10``, they will be saved after the epoch 10, 20, 30, etc.     
 
 ##### c. Epochs
-- Total amount of <u>[epochs](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/)</u> for the model.
-- But since we'll use <u>[TensorBoard](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u>, use an arbitrarily large number like ``2000``.
+- Total amount of <u>[epochs](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/)</u> for the model.
+- But since we'll use <u>[TensorBoard](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u>, use an arbitrarily large number like ``2000``.
 
 ##### d. Batch size
 - If you are a newbie, leave it at `8`. If your dataset is smaller (around 2 minutes or less) use `4` instead.
@@ -368,7 +368,7 @@ ii. To download it, open the file explorer & go to RVC, logs, and in your model'
 ##### e. Start training
 i. Begin training by running said cell. All the training files will be stored in your GD storage, so 
 
-ii. <u>[TB](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u> will open in a momment. Remember to monitor it, as well as the cell's logs just in case.     
+ii. <u>[TB](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u> will open in a momment. Remember to monitor it, as well as the cell's logs just in case.     
 
     The latter will show you errors if they happen, and information about the epochs & checkpoints.   
 
@@ -379,7 +379,7 @@ ii. <u>[TB](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/#tensorboar
 - <u>[Stay AFK](https://docs.google.com/document/d/1Pr-AZndodmWgsbOeuHQU4IrgbatFgYc1ChOq_ZAf_5s/edit?usp=sharing)</u> for a long time.     
 - Disconnect from your Internet.       
 - Don't solve the captchas that (might) pop up occasionally.    
-- Run out of <u>[GPU runtime](https://docs.aihub.wtf/rvc/extra/glossary/#google-colab)</u>. 
+- Run out of <u>[GPU runtime](https://docs.ai-hub.wtf/rvc/extra/glossary/#google-colab)</u>. 
 !!!
 
 - If the session ends due to exhausting GPU runtime, don't worry, if you followed the [Setting Up]() procedure, all the training files will be stored in your GD storage.
@@ -397,5 +397,5 @@ ii. <u>[TB](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/#tensorboar
 :::content-center
 #### `You have reached the end.`
 
-[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.aihub.wtf/rvc/#contributions)
+[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.ai-hub.wtf/rvc/#contributions)
 :::

--- a/assets/RVC/Cloud/Paperspace.md
+++ b/assets/RVC/Cloud/Paperspace.md
@@ -122,5 +122,5 @@ On the other hand, on Colab, it might take around 7 hours (without considering t
 :::content-center
 #### `You have reached the end.`
 
-[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.aihub.wtf/rvc/#contributions)
+[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.ai-hub.wtf/rvc/#contributions)
 :::

--- a/assets/RVC/Cloud/RVC Disconnected.md
+++ b/assets/RVC/Cloud/RVC Disconnected.md
@@ -10,9 +10,9 @@ order: 3000
 ## Introduction :icon-book:
 :::
 ###### ‎              
-- RVC Disconnected (or RVC-D) is a port of <u>[Mangio](https://docs.aihub.wtf/rvc/local/mangio/)</u> to <u>[Google Colab</u>](https://docs.aihub.wtf/extra/glossary/#google-colab), for exclusively training. Notebook made by <u>[Kit Lemonfoot</u>](https://huggingface.co/Kit-Lemonfoot).
+- RVC Disconnected (or RVC-D) is a port of <u>[Mangio](https://docs.ai-hub.wtf/rvc/local/mangio/)</u> to <u>[Google Colab</u>](https://docs.ai-hub.wtf/extra/glossary/#google-colab), for exclusively training. Notebook made by <u>[Kit Lemonfoot</u>](https://huggingface.co/Kit-Lemonfoot).
 
-- It's free, includes all the necessary tools for a quality model, the <u>[TensorBoard</u>](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/#tensorboard), & it's the fastest Colab space for training.    
+- It's free, includes all the necessary tools for a quality model, the <u>[TensorBoard</u>](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/#tensorboard), & it's the fastest Colab space for training.    
 
 - Making it the go-to method for training for cloud RVC users. Pretty much the only big downside is the time limit (but you can switch to another account & continue).      
 ‎       
@@ -42,7 +42,7 @@ order: 3000
 
 ###### ‎ 
 !!!warning WARNING:
-1.‎ The guide is centered around the <u>[TensorBoard](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u>. Read it first if you haven't already.    
+1.‎ The guide is centered around the <u>[TensorBoard](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u>. Read it first if you haven't already.    
 2. Turn on <u>[third-party cookies</u>](https://cleeng.zendesk.com/hc/en-us/articles/360009526800-How-to-enable-third-party-cookies-on-my-browser-), or TB might not work.
 !!!
 :::
@@ -97,13 +97,13 @@ a. Go to the `Set Training Variables` cell.
 :   If you aren't familiar with pretrains, select `original`.
 
 `target_sample_rate`
-:   Select your dataset's <u>[sample rate</u>](https://docs.aihub.wtf/rvc/resources/datasets/#sample-rate).
+:   Select your dataset's <u>[sample rate</u>](https://docs.ai-hub.wtf/rvc/resources/datasets/#sample-rate).
 
 ``pitch_extraction_algorithm``
-:   The <u>[extraction method](https://docs.aihub.wtf/rvc/resources/inference-settings/#pitch-extraction-algorithm)</u>. Don't use Harvest, as it's obsolete.        
+:   The <u>[extraction method](https://docs.ai-hub.wtf/rvc/resources/inference-settings/#pitch-extraction-algorithm)</u>. Don't use Harvest, as it's obsolete.        
 
 `crepe_hop_length`
-:   If you chose `Mangio-Crepe`, this defines the <u>[Hop Length](https://docs.aihub.wtf/rvc/resources/inference-settings/#mangio-crepe)</u>.
+:   If you chose `Mangio-Crepe`, this defines the <u>[Hop Length](https://docs.ai-hub.wtf/rvc/resources/inference-settings/#mangio-crepe)</u>.
 
 ***
 ###### ‎ 
@@ -120,7 +120,7 @@ b. Below, execute **Preprocessing, Feature Extraction**, & **Save preprocessed d
 ***
 ###### ‎ 
 #### 3. Train Index  
-a. Run **Index Training** to create the model's <u>[.INDEX</u>](https://docs.aihub.wtf/essentials/voice-models/#voice-model-files) file.      
+a. Run **Index Training** to create the model's <u>[.INDEX</u>](https://docs.ai-hub.wtf/essentials/voice-models/#voice-model-files) file.      
 
     <img src="../rvcdisconnected-img/17.png" alt="image" width="450" height="auto">‎        
 ‎       
@@ -137,11 +137,11 @@ b. To download it, in GD open `rvcDisconnected` & the folder named after the mod
 - #### <u>Define these values:</u>
 
 `save_frequency`
-:   Frequency of the <u>[saving checkpoints](https://docs.aihub.wtf/extra/glossary/#checkpoints)</u>, based on the <u>[epochs](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/)</u>. If you're a newbie, simply leave it at `15`.      
+:   Frequency of the <u>[saving checkpoints](https://docs.ai-hub.wtf/extra/glossary/#checkpoints)</u>, based on the <u>[epochs](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/)</u>. If you're a newbie, simply leave it at `15`.      
 <u>E.g:</u> with a value of ``10``, it will be saved after the epoch 10, 20, 30, etc.   
 
 `total_epochs`
-:   The total amount of <u>[epochs](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/)</u> for the model. But since we'll use <u>[TensorBoard](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u>, use an arbitrarily large number like ``2000``.
+:   The total amount of <u>[epochs](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/)</u> for the model. But since we'll use <u>[TensorBoard](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u>, use an arbitrarily large number like ``2000``.
 
 `batch_size`
 :   Use ``8`` if you are a newbie.
@@ -150,7 +150,7 @@ But if your dataset is small (around 2 minutes or less), use ``4``.
 ***
 ###### ‎ 
 #### 5. Begin training
-- Execute the **Training** cell to begin training. <u>[TB](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u> will open up after a few seconds, & the graphs will take a minute to appear.         
+- Execute the **Training** cell to begin training. <u>[TB](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u> will open up after a few seconds, & the graphs will take a minute to appear.         
 ‎    
 - Remember to monitor it, as well as the cell's logs. The latter will show you errors if they happen, and information about the epochs & checkpoints.         
 ‎       
@@ -158,7 +158,7 @@ But if your dataset is small (around 2 minutes or less), use ``4``.
    - <u>[Stay AFK](https://docs.google.com/document/d/1Pr-AZndodmWgsbOeuHQU4IrgbatFgYc1ChOq_ZAf_5s/edit?usp=sharing)</u> for a long time.     
    - Disconnect from your Internet.       
    - Don't solve the captchas that (might) pop up occasionally.    
-   - Run out of <u>[GPU runtime](https://docs.aihub.wtf/rvc/extra/glossary/#google-colab)</u>.     
+   - Run out of <u>[GPU runtime](https://docs.ai-hub.wtf/rvc/extra/glossary/#google-colab)</u>.     
 
 ***
 ###### ‎ 
@@ -173,7 +173,7 @@ But if your dataset is small (around 2 minutes or less), use ``4``.
 
     <img src="../rvcdisconnected-img/22.png" alt="image" width="330" height="auto">‎        
 ‎       
-3. Once your GPU runtime resets, begin the <u>[retraining](https://docs.aihub.wtf/rvc/cloud/rvc-disconnected/#resuming-)</U> procedure.
+3. Once your GPU runtime resets, begin the <u>[retraining](https://docs.ai-hub.wtf/rvc/cloud/rvc-disconnected/#resuming-)</U> procedure.
 
 - After exporting, you are free to resume training until runtime is exhausted or close the session.
 ***
@@ -184,7 +184,7 @@ a. When you're very sure of overtraining, you can stop training by pressing the 
 b. Click the folder symbol on the left.     
 (For mobile users: tap the three lines on the top left & `Show file browser`)     
 
-    Open the ``Mangio-RVC-Fork`` folder, then `weights`. You'll find the <u>[checkpoints](https://docs.aihub.wtf/extra/glossary/#checkpoints)</u>.    
+    Open the ``Mangio-RVC-Fork`` folder, then `weights`. You'll find the <u>[checkpoints](https://docs.ai-hub.wtf/extra/glossary/#checkpoints)</u>.    
 
     <img src="../rvcdisconnected-img/20.png" alt="image" width="210" height="auto">‎    
 ‎   
@@ -193,7 +193,7 @@ c. Right-click the one that's **closest** to ***before*** the overtraining point
     The models will be organized with this format: **Name_Epoch_Step.pth**.       
     E.g: `arianagrande_e60_s120.pth`    
 ‎   
-d. And that's all. To test it, do a normal <u>[inference](https://docs.aihub.wtf/essentials/how-to-make-ai-cover/)</u> as usual.
+d. And that's all. To test it, do a normal <u>[inference](https://docs.ai-hub.wtf/essentials/how-to-make-ai-cover/)</u> as usual.
 
 ***
 :::content-center
@@ -222,12 +222,12 @@ d. And that's all. To test it, do a normal <u>[inference](https://docs.aihub.wtf
 ***
 4. You can change the **save frequency** or increase the **total epochs**, in case you didn't input enough before.
 ***
-5. Run the **Training** cell to retrain. Remember to monitor <u>[TB</u>](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/#tensorboard) as before.       
+5. Run the **Training** cell to retrain. Remember to monitor <u>[TB</u>](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/#tensorboard) as before.       
 
 ***
 ###### ‎
 :::content-center
 #### `You have reached the end.`
 
-[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.aihub.wtf/rvc/#contributions)
+[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.ai-hub.wtf/rvc/#contributions)
 :::

--- a/assets/RVC/Local/Applio.md
+++ b/assets/RVC/Local/Applio.md
@@ -21,7 +21,7 @@ order: 5000
 
 - Because of its user-friendly experience & active development, it's considered to be one of the best forks.     
 
-- It also has a <u>[cloud version](https://colab.research.google.com/github/iahispano/applio/blob/master/assets/Applio.ipynb)</u>, in case you don't meet the <u>[requirements](https://docs.aihub.wtf/essentials/whats-rvc/#what-are-the-requirements-for-rvc-locally/)</u> to run it locally.     
+- It also has a <u>[cloud version](https://colab.research.google.com/github/iahispano/applio/blob/master/assets/Applio.ipynb)</u>, in case you don't meet the <u>[requirements](https://docs.ai-hub.wtf/essentials/whats-rvc/#what-are-the-requirements-for-rvc-locally/)</u> to run it locally.     
 ‎      
 #### Pros & Cons :icon-tasklist:
 ==- *Learn more*
@@ -77,14 +77,14 @@ order: 5000
 :::content-center
 ## Inference :icon-unmute:   
 !!!success
-If you encounter an issue, be sure to read the <u>[Troubleshooting](https://docs.aihub.wtf/rvc/local/mainline/#troubleshooting-)</u> chapter.
+If you encounter an issue, be sure to read the <u>[Troubleshooting](https://docs.ai-hub.wtf/rvc/local/mainline/#troubleshooting-)</u> chapter.
 !!!
 :::
 ###### ‎  
 ###### ‎   
 #### 1. Upload voice model.
 - Go to the **Download** tab.       
-You have two ways of uploading it: through <u>[**its link**](https://docs.aihub.wtf/essentials/voice-models/#how-to-search-voice-models)</u> or **manually** inputting its files.
+You have two ways of uploading it: through <u>[**its link**](https://docs.ai-hub.wtf/essentials/voice-models/#how-to-search-voice-models)</u> or **manually** inputting its files.
 
     +++ Link
     a. Go to the **Download** tab & paste the link of the model in the `Model Link` bar. It must be from Hugging Face or Google Drive.        
@@ -140,7 +140,7 @@ b. Select your model in the ``Voice Model`` dropdown.
 
 ‎  
 #### 4. Modify settings. (optional)      
--  Unfold `Advanced Settings` if you wish to modify the <u>[inference settings](https://docs.aihub.wtf/rvc/resources/inference-settings/)</u> for better results, or to determine the output folder.
+-  Unfold `Advanced Settings` if you wish to modify the <u>[inference settings](https://docs.ai-hub.wtf/rvc/resources/inference-settings/)</u> for better results, or to determine the output folder.
 
     <img src="..\applio-img/3-advanced.png" alt="image" width="600">‎   
 ***
@@ -160,8 +160,8 @@ b. Once it's done, you can hear the results in the **Export Audio** box below.
 ## Training :icon-dependabot:
 ###### ‎   
 !!!warning
-The training guide will be centered around using <u>[TensorBoard](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u>. Read about it first if you haven't already.      
-If you encounter an issue, be sure to read the <u>[Troubleshooting](https://docs.aihub.wtf/rvc/local/mainline/#troubleshooting-)</u> chapter.
+The training guide will be centered around using <u>[TensorBoard](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u>. Read about it first if you haven't already.      
+If you encounter an issue, be sure to read the <u>[Troubleshooting](https://docs.ai-hub.wtf/rvc/local/mainline/#troubleshooting-)</u> chapter.
 !!!
 :::
 ###### ‎     
@@ -188,7 +188,7 @@ Don't include spaces/special characters.
 ###### ‎     
 ##### c. Sampling Rate
 ###### ‎    
-- Select your dataset's sample rate. If you don't know the amount, click <u>[here](https://docs.aihub.wtf/rvc/local/applio/#extra)</u>.
+- Select your dataset's sample rate. If you don't know the amount, click <u>[here](https://docs.ai-hub.wtf/rvc/local/applio/#extra)</u>.
 
     <img src="..\applio-img\4-samplerate.png" alt="image" width="300">‎  
 
@@ -208,7 +208,7 @@ Don't include spaces/special characters.
 ###### ‎    
 ##### a. Pitch extraction algorithm
 ###### ‎  
-- Select the <u>[algorithm](https://docs.aihub.wtf/rvc/resources/inference-settings/#pitch-extraction-algorithm)</u> you want. Use either ``Crepe`` or ``RMVPE``, as the rest are outdated.
+- Select the <u>[algorithm](https://docs.ai-hub.wtf/rvc/resources/inference-settings/#pitch-extraction-algorithm)</u> you want. Use either ``Crepe`` or ``RMVPE``, as the rest are outdated.
 
     <img src="..\applio-img\4-f0.png" alt="image" width="400">
 
@@ -216,7 +216,7 @@ Don't include spaces/special characters.
 ###### ‎  
 ##### b. Hop Length (optional)
 ###### ‎  
-- If you chose ``Crepe``, you can modify its <u>[hop length](https://docs.aihub.wtf/rvc/resources/inference-settings/#mangio-crepe)</u>.
+- If you chose ``Crepe``, you can modify its <u>[hop length](https://docs.ai-hub.wtf/rvc/resources/inference-settings/#mangio-crepe)</u>.
 
     <img src="..\applio-img\4-hoplength.png" alt="image" width="900">
 
@@ -243,7 +243,7 @@ It'll finish when it says `extracted successfully`.
 ###### ‎  
 ##### b. Save Every Epoch
 ###### ‎  
-- Frequency of the <u>[saving checkpoints](https://docs.aihub.wtf/extra/glossary/#checkpoints)</u>, based on the <u>[epochs](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/)</u>.      
+- Frequency of the <u>[saving checkpoints](https://docs.ai-hub.wtf/extra/glossary/#checkpoints)</u>, based on the <u>[epochs](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/)</u>.      
 ‎   
 - If you are a newbie, simply leave it at `15`.              
 
@@ -255,9 +255,9 @@ It'll finish when it says `extracted successfully`.
 ###### ‎  
 ##### c. Total Epoch
 ###### ‎  
-- Input the total amount of <u>[epochs](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/)</u> (training cycles) for the model.     
+- Input the total amount of <u>[epochs](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/)</u> (training cycles) for the model.     
 ‎   
-- But since we'll use <u>[TensorBoard](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u>, use an arbitrarily large value like `1000`
+- But since we'll use <u>[TensorBoard](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u>, use an arbitrarily large value like `1000`
 
     <img src="..\applio-img\4-epoch.png" alt="image" width="420">‎   
 ***
@@ -271,14 +271,14 @@ It'll finish when it says `extracted successfully`.
 ###### ‎  
 ##### e. Generate Index
 ###### ‎  
-- Click `Generate Index`. This will create the model's <u>[.INDEX](https://docs.aihub.wtf/essentials/voice-models/#voice-model-files)</u> file.
+- Click `Generate Index`. This will create the model's <u>[.INDEX](https://docs.ai-hub.wtf/essentials/voice-models/#voice-model-files)</u> file.
 ***
 ###### ‎  
 ##### f. Start Training
 ###### ‎  
 - Press `Start Training` to begin the training process.     
 ‎   
-- To open <u>[TB](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u>, execute `run-tensorboard` in Applio's folder. Remember to monitor it, as well as the console just in case.           
+- To open <u>[TB](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u>, execute `run-tensorboard` in Applio's folder. Remember to monitor it, as well as the console just in case.           
 ‎   
 - The latter will show you errors if they happen, and information about the epochs & checkpoints.   
 
@@ -311,7 +311,7 @@ iii. Select the **.INDEX** named ``added_`` & move it to your newly made folder.
 ###### ‎  
 ##### c. Get the PTH
 ###### ‎  
-i. In said folder you'll also find all the <u>[checkpoints](https://docs.aihub.wtf/extra/glossary/#checkpoints)</u>.         
+i. In said folder you'll also find all the <u>[checkpoints](https://docs.ai-hub.wtf/extra/glossary/#checkpoints)</u>.         
 ‎  
 ii. Select the one **closest** to ***before*** the overtraining point, and move it to the new folder.
 
@@ -320,7 +320,7 @@ ii. Select the one **closest** to ***before*** the overtraining point, and move 
 
 ‎  
     ‎            
-iii. And that's all, have fun with your model. To test it, do a normal <u>[inference</u>](https://docs.aihub.wtf/rvc/local/applio/#inference-) as usual.
+iii. And that's all, have fun with your model. To test it, do a normal <u>[inference</u>](https://docs.ai-hub.wtf/rvc/local/applio/#inference-) as usual.
 
 ===
 
@@ -344,9 +344,9 @@ iii. And that's all, have fun with your model. To test it, do a normal <u>[infer
 ###### ‎  
 - Applio is also known for having one TTS tool by default, with **plenty** of voices to choose for.
 
-- You can also use it with **RVC models** & apply the <u>[inference settings](https://docs.aihub.wtf/rvc/resources/inference-settings/)</u> if you wish.
+- You can also use it with **RVC models** & apply the <u>[inference settings](https://docs.ai-hub.wtf/rvc/resources/inference-settings/)</u> if you wish.
 
-- Aditionally, you can download the **Eleven Labs** TTS <u>[plugin](https://docs.aihub.wtf/rvc/local/applio/#plugins)</u>.       
+- Aditionally, you can download the **Eleven Labs** TTS <u>[plugin](https://docs.ai-hub.wtf/rvc/local/applio/#plugins)</u>.       
 ***
 ###### ‎  
 #### <u>Instructions:</u>
@@ -357,11 +357,11 @@ iii. And that's all, have fun with your model. To test it, do a normal <u>[infer
 ***   
 ###### ‎   
 
-2. If you want to use an RVC model, <u>[download it](https://docs.aihub.wtf/rvc/local/applio/#1-upload-voice-model)</u>, go to **TTS**, click `Refresh` & select it in **Voice Model** & **Index File**.
+2. If you want to use an RVC model, <u>[download it](https://docs.ai-hub.wtf/rvc/local/applio/#1-upload-voice-model)</u>, go to **TTS**, click `Refresh` & select it in **Voice Model** & **Index File**.
 
    <img src="../applio-img/5-vm.png" alt="image" width="600" height="auto">‎    
 ‎             
-- To modify the <u>[inference settings](https://docs.aihub.wtf/rvc/resources/inference-settings/)</u> or the output folder for the TTS/RVC audio, unfold `Advanced Settings`.
+- To modify the <u>[inference settings](https://docs.ai-hub.wtf/rvc/resources/inference-settings/)</u> or the output folder for the TTS/RVC audio, unfold `Advanced Settings`.
 
 ***
 ###### ‎      
@@ -481,13 +481,13 @@ Then you'll be able to see the plugin in the **Plugins** tab.
 
 ==- *The voice glitches out.*
 ###### ‎   
-- This a phenomenon called artifacting. To fix it, read <u>[here](https://docs.aihub.wtf/rvc/resources/artifacting/)</u>.
+- This a phenomenon called artifacting. To fix it, read <u>[here](https://docs.ai-hub.wtf/rvc/resources/artifacting/)</u>.
 
 ===
 
 ==- *I couldn't find my answer.*
 ###### ‎   
-- Report your issue <u>[here](https://docs.aihub.wtf/rvc/#contributions)</u>.
+- Report your issue <u>[here](https://docs.ai-hub.wtf/rvc/#contributions)</u>.
 ===
 
 ***
@@ -495,5 +495,5 @@ Then you'll be able to see the plugin in the **Plugins** tab.
 :::content-center
 #### `You have reached the end.`
 
-[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.aihub.wtf/rvc/#contributions)
+[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.ai-hub.wtf/rvc/#contributions)
 :::

--- a/assets/RVC/Local/Mainline.md
+++ b/assets/RVC/Local/Mainline.md
@@ -13,7 +13,7 @@ order: 4000
 
 - Mainline RVC is the base, original, & unmodified version of RVC. Made by the <u>[RVC-Project</u>](https://github.com/RVC-Project) team.
 
-- It has less features compared to other <u>[forks</u>](https://docs.aihub.wtf/essentials/whats-rvc/#forks), but still has the necessary tools to do a decent job.
+- It has less features compared to other <u>[forks</u>](https://docs.ai-hub.wtf/essentials/whats-rvc/#forks), but still has the necessary tools to do a decent job.
 
 - It's specially liked because it's a little faster than other forks, as it's less bloated in a way. 
 
@@ -30,7 +30,7 @@ order: 4000
 - A bit faster compared w/ other forks. 
 ||| ❌ **CONS** 
 - Has less features.     
-- Doesn't include <u>[Mangio-Crepe</u>](https://docs.aihub.wtf/rvc/resources/inference-settings/#pitch-extraction-algorithm).      
+- Doesn't include <u>[Mangio-Crepe</u>](https://docs.ai-hub.wtf/rvc/resources/inference-settings/#pitch-extraction-algorithm).      
 - Manual model upload.
 ||| 
 ===
@@ -66,17 +66,17 @@ order: 4000
 :::content-center
 ## Inference :icon-unmute:   
 !!!success
-If you encounter an issue, be sure to read the <u>[Troubleshooting](https://docs.aihub.wtf/rvc/local/mainline/#troubleshooting-)</u> chapter.
+If you encounter an issue, be sure to read the <u>[Troubleshooting](https://docs.ai-hub.wtf/rvc/local/mainline/#troubleshooting-)</u> chapter.
 !!!
 :::
 ###### ‎   
 #### 1. Upload voice model.
-a. Open RVC's folder, go to the `assets` folder and put your model's <u>[**.PTH**</u>](https://docs.aihub.wtf/essentials/voice-models/#voice-model-files) file inside the `weights` folder.       
+a. Open RVC's folder, go to the `assets` folder and put your model's <u>[**.PTH**</u>](https://docs.ai-hub.wtf/essentials/voice-models/#voice-model-files) file inside the `weights` folder.       
     ‎       
     <img src="../mainline-img/5.png" alt="image" width="520" height="auto">      
 ‎       
        
-b. Return to the previous folder & put the model's <u>[**.INDEX**</u>](https://docs.aihub.wtf/essentials/voice-models/#voice-model-files) file in the `logs` folder.
+b. Return to the previous folder & put the model's <u>[**.INDEX**</u>](https://docs.ai-hub.wtf/essentials/voice-models/#voice-model-files) file in the `logs` folder.
 
     <img src="../mainline-img/6.png" alt="image" width="520" height="auto"> 
 
@@ -102,7 +102,7 @@ In ``Enter the path of the audio file`` paste the <u>[path file</u>](https://sta
 ***
 ###### ‎  
 #### 4. Modify settings. (optional)      
-If you wish, modify the <u><u>[inference settings</u>](https://docs.aihub.wtf/rvc/resources/inference-settings/)</u> on display accordingly for better results.
+If you wish, modify the <u><u>[inference settings</u>](https://docs.ai-hub.wtf/rvc/resources/inference-settings/)</u> on display accordingly for better results.
 ***
 ###### ‎  
 #### 5. Convert.
@@ -123,9 +123,9 @@ To download, click the three dots on the right & hit `Download`.
 ## Training :icon-dependabot:
 ###### ‎   
 !!!warning <u> NOTES: </u>
-The training guide will be centered around using [TensorBoard](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/#tensorboard). Read about it first if you haven't already.      
+The training guide will be centered around using [TensorBoard](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/#tensorboard). Read about it first if you haven't already.      
 
-If you encounter an issue, be sure to read the <u>[Troubleshooting](https://docs.aihub.wtf/rvc/local/mainline/#troubleshooting-)</u> chapter.
+If you encounter an issue, be sure to read the <u>[Troubleshooting](https://docs.ai-hub.wtf/rvc/local/mainline/#troubleshooting-)</u> chapter.
 !!!
 :::
 ###### ‎     
@@ -149,7 +149,7 @@ In `Enter the experiment name` you insert a name for your model. Don't include s
 
 ###### ‎  
 #### 3. Select Target Sample Rate.
-In `Target sample rate` select the number that matches your datasets' <u>[sample rate</u>](https://docs.aihub.wtf/rvc/resources/datasets/#sample-rate).        
+In `Target sample rate` select the number that matches your datasets' <u>[sample rate</u>](https://docs.ai-hub.wtf/rvc/resources/datasets/#sample-rate).        
 Inputting an incorrect one might screw up the final quality.
 
 <img src="../mainline-img/g.png" alt="image" width="" height="auto">         
@@ -201,7 +201,7 @@ In `Enter the GPU index(es)` determine which GPU(s) you'll use for training, by 
 ***
 ###### ‎  
 #### 7. Select pitch extraction algorithm.
-a. At the right select the <u>[**Pitch extraction algorithm**](https://docs.aihub.wtf/rvc/resources/inference-settings/#pitch-extraction-algorithm)</u>.       
+a. At the right select the <u>[**Pitch extraction algorithm**](https://docs.ai-hub.wtf/rvc/resources/inference-settings/#pitch-extraction-algorithm)</u>.       
 Only use ``RMVPE_GPU`` or ``Crepe``, as the rest are obsolete.      
 
     <img src="../mainline-img/16.png" alt="image" width="" height="auto"> ‎      
@@ -220,7 +220,7 @@ b. Now click the `Feature extraction` button on the right.
 ###### ‎  
 #### 8. Create .INDEX.
 Press `Train feature index` at the bottom center.       
-This will create the <u>[.INDEX</u>](https://docs.aihub.wtf/essentials/voice-models/#voice-model-files) file.
+This will create the <u>[.INDEX</u>](https://docs.ai-hub.wtf/essentials/voice-models/#voice-model-files) file.
 
 <img src="../mainline-img/i.png" alt="image" width="250" height="auto">‎     
 ‎       
@@ -235,7 +235,7 @@ It'll finish when the output box says something like this:
 :::
 ###### ‎           
 #### 9. Select save frequency.
-Frequency of the <u>[saving checkpoints](https://docs.aihub.wtf/extra/glossary/#checkpoints)</u>, based on the <u>[epochs](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/)</u>.        
+Frequency of the <u>[saving checkpoints](https://docs.ai-hub.wtf/extra/glossary/#checkpoints)</u>, based on the <u>[epochs](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/)</u>.        
 
 If you are a newbie, simply leave it at `15`.        
     
@@ -247,9 +247,9 @@ E.g: with a value of ``10``, they will be saved after the epoch 10, 20, 30, etc.
 ***
 ###### ‎  
 #### 10. Input epochs amount.
-In `Total training epochs` you determine the total amount of <u>[epochs](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/)</u> (training cycles) for the model.     
+In `Total training epochs` you determine the total amount of <u>[epochs](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/)</u> (training cycles) for the model.     
 
-But since we'll use [TensorBoard](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/#tensorboard), use an arbitrarily large value like `2000`.
+But since we'll use [TensorBoard](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/#tensorboard), use an arbitrarily large value like `2000`.
 
 <img src="../mainline-img/19.png" alt="image" width="" height="auto">  
 
@@ -267,7 +267,7 @@ If your dataset is short (around 2 minutes or less), use ``4`` instead.
 #### 12. Launch TensorBoard.
 Now before you start training, open TB.     
 
-If you haven't already, start reading about it here <u><u>[here</u>](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u>.
+If you haven't already, start reading about it here <u><u>[here</u>](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u>.
 ***
 ###### ‎  
 #### 13. Begin training.
@@ -298,7 +298,7 @@ Select the `.INDEX` named ``added_`` & move it to your newly made folder.
 
 ‎   
 
-c. Now go to the ``weights`` folder. Here you'll find the model's <u>[checkpoints](https://docs.aihub.wtf/extra/glossary/#checkpoints)</u>.      
+c. Now go to the ``weights`` folder. Here you'll find the model's <u>[checkpoints](https://docs.ai-hub.wtf/extra/glossary/#checkpoints)</u>.      
 
     Select the one **closest** to ***before*** the overtraining point, and move it to the new folder      
 
@@ -310,7 +310,7 @@ c. Now go to the ``weights`` folder. Here you'll find the model's <u>[checkpoint
     ‎            
 
     And that's all. Have fun with your model.   
-    To test the model, do a normal <u>[inference</u>](https://docs.aihub.wtf/essentials/how-to-make-ai-cover/) as usual.
+    To test the model, do a normal <u>[inference</u>](https://docs.ai-hub.wtf/essentials/how-to-make-ai-cover/) as usual.
 
 ***
 ###### ‎   
@@ -321,7 +321,7 @@ c. Now go to the ``weights`` folder. Here you'll find the model's <u>[checkpoint
 If the training finished but the model still needed training, you don't have to start from scratch.       
 **Follow this procedure:**
 
-- Simply enter the **same settings and criteria** that you previously inserted. Model name, sample rate, dataset, batch size, etc. You don't have to press ``Process Data`` or train the <u>[.INDEX</u>](https://docs.aihub.wtf/essentials/voice-models/#voice-model-files) again.
+- Simply enter the **same settings and criteria** that you previously inserted. Model name, sample rate, dataset, batch size, etc. You don't have to press ``Process Data`` or train the <u>[.INDEX</u>](https://docs.ai-hub.wtf/essentials/voice-models/#voice-model-files) again.
 
 - You can change the **save frequency**, or increase the **epochs** amount in case you didn't input enough before.
 
@@ -348,7 +348,7 @@ If the training finished but the model still needed training, you don't have to 
 
 ==- *The voice glitches out.*
 ###### ‎   
-- This a phenomenon called artifacting. To fix it, read <u>[here](https://docs.aihub.wtf/rvc/resources/artifacting/)</u>.
+- This a phenomenon called artifacting. To fix it, read <u>[here](https://docs.ai-hub.wtf/rvc/resources/artifacting/)</u>.
 
 ===
 
@@ -358,7 +358,7 @@ If the training finished but the model still needed training, you don't have to 
 
 ==- *I couldn't find my answer.*
 ###### ‎   
-- Report your issue <u>[here](https://docs.aihub.wtf/rvc/#contributions)</u>.
+- Report your issue <u>[here](https://docs.ai-hub.wtf/rvc/#contributions)</u>.
 ===
 
 ***
@@ -366,5 +366,5 @@ If the training finished but the model still needed training, you don't have to 
 :::content-center
 #### `You have reached the end.`
 
-[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.aihub.wtf/rvc/#contributions)
+[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.ai-hub.wtf/rvc/#contributions)
 :::

--- a/assets/RVC/Local/Mangio.md
+++ b/assets/RVC/Local/Mangio.md
@@ -10,9 +10,9 @@ order: 2000
 :::content-center
 ## Introduction ‎ :icon-book:
 :::   
-- Mangio RVC is a <u>[fork</u>](https://docs.aihub.wtf/essentials/whats-rvc/#forks) of RVC, [Mangio621](https://github.com/Mangio621), [Kalomaze](https://github.com/kalomaze), & [Alexolotl](https://github.com/alexlnkp)
+- Mangio RVC is a <u>[fork</u>](https://docs.ai-hub.wtf/essentials/whats-rvc/#forks) of RVC, [Mangio621](https://github.com/Mangio621), [Kalomaze](https://github.com/kalomaze), & [Alexolotl](https://github.com/alexlnkp)
 
-- Considered one of the best forks out there. Mainly because of it's extra features, inclusion of <u>[Mangio-Crepe](https://docs.aihub.wtf/rvc/resources/inference-settings/#pitch-extraction-algorithm)</u>, & its stability.
+- Considered one of the best forks out there. Mainly because of it's extra features, inclusion of <u>[Mangio-Crepe](https://docs.ai-hub.wtf/rvc/resources/inference-settings/#pitch-extraction-algorithm)</u>, & its stability.
 
 - The project nowadays is a little abandoned, so don't expect many updates from the developers soon, unfortunately.     
 
@@ -26,9 +26,9 @@ order: 2000
 - Easy to install.      
 - Includes Mangio-Crepe algorithm.        
 - Nicer UI.       
-- More features than <u>[Mainline</u>](https://docs.aihub.wtf/rvc/local/mainline/).        
+- More features than <u>[Mainline</u>](https://docs.ai-hub.wtf/rvc/local/mainline/).        
 - Has hybrid training.        
-- Lighter storage-wise if you install the <u>[inference</u>](https://docs.aihub.wtf/extra/glossary/#inference)</u>)-only version.
+- Lighter storage-wise if you install the <u>[inference</u>](https://docs.ai-hub.wtf/extra/glossary/#inference)</u>)-only version.
 ||| ❌ **CONS** 
 - A little slower than Mainline, since it's more bloated.     
 - Will likely remain with no updates for a long time.      
@@ -43,7 +43,7 @@ order: 2000
 :::
 ###### ‎   
 
-1. For exclusively <u>[**inferencing**](https://docs.aihub.wtf/extra/glossary/#inference)</u>, click <u>[here</u>](https://huggingface.co/MangioRVC/Mangio-RVC-Huggingface/resolve/main/Mangio-RVC-v23.7.0_INFER.7z).      
+1. For exclusively <u>[**inferencing**](https://docs.ai-hub.wtf/extra/glossary/#inference)</u>, click <u>[here</u>](https://huggingface.co/MangioRVC/Mangio-RVC-Huggingface/resolve/main/Mangio-RVC-v23.7.0_INFER.7z).      
     For both inferencing **& training**, click <u>[here</u>](https://huggingface.co/MangioRVC/Mangio-RVC-Huggingface/resolve/main/Mangio-RVC-v23.7.0_INFER_TRAIN.7z).     
 
 2. Once it's done downloading, unzip the folder.
@@ -69,12 +69,12 @@ order: 2000
 ## Inference :icon-unmute:
 ###### ‎       
 !!!success
-If you encounter an issue, be sure to read the <u>[Troubleshooting](https://docs.aihub.wtf/rvc/local/mangio/#troubleshooting-)</u> chapter.
+If you encounter an issue, be sure to read the <u>[Troubleshooting](https://docs.ai-hub.wtf/rvc/local/mangio/#troubleshooting-)</u> chapter.
 !!!
 :::
 ###### ‎    
 #### 1. Upload voice model.
-a. Open Mangio's folder & put your model's <u>[**.PTH**](https://docs.aihub.wtf/essentials/voice-models/#voice-model-files)</u> file inside the `weights` folder.
+a. Open Mangio's folder & put your model's <u>[**.PTH**](https://docs.ai-hub.wtf/essentials/voice-models/#voice-model-files)</u> file inside the `weights` folder.
 
     <img src="../mangio-img/g.png" alt="image" width="500" height="auto"> 
 ###### ‎       
@@ -108,7 +108,7 @@ If there are multiple audios in said path, click `Select audio path from the dro
 ***
 ###### ‎  
 #### 4. Modify settings. (optional)      
-If you wish, modify the <u>[inference settings](https://docs.aihub.wtf/rvc/resources/inference-settings/)</u> on display accordingly for better results.
+If you wish, modify the <u>[inference settings](https://docs.ai-hub.wtf/rvc/resources/inference-settings/)</u> on display accordingly for better results.
 ***
 ###### ‎  
 #### 5. Convert.
@@ -130,9 +130,9 @@ Your output audios will be located in Mangio's `audio-outputs` folder.
 ## Training :icon-dependabot:
 ###### ‎     
 !!!warning <u> NOTES: </u>
-The training guide will be centered around using <u>[TensorBoard](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u>. Read about it first if you haven't already.      
+The training guide will be centered around using <u>[TensorBoard](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u>. Read about it first if you haven't already.      
 
-If you encounter an issue, be sure to read the <u>[Troubleshooting](https://docs.aihub.wtf/rvc/local/mangio/#troubleshooting-)</u> chapter.
+If you encounter an issue, be sure to read the <u>[Troubleshooting](https://docs.ai-hub.wtf/rvc/local/mangio/#troubleshooting-)</u> chapter.
 !!!
 :::
 ###### ‎    
@@ -157,7 +157,7 @@ In `Enter the experiment name` you insert a name for your model. Don't include s
 
 ###### ‎  
 #### 3. Select Target Sample Rate.
-In `Target sample rate` select the number that matches your dataset's [<u>sample rate</u>](https://docs.aihub.wtf/rvc/resources/datasets/#sample-rate).        
+In `Target sample rate` select the number that matches your dataset's [<u>sample rate</u>](https://docs.ai-hub.wtf/rvc/resources/datasets/#sample-rate).        
 Inputting an incorrect one might screw up the final quality.
 
 <img src="../mangio-img/6.png" alt="image" width="" height="auto">         
@@ -206,7 +206,7 @@ In `Enter the GPU index(es)` determine which GPU(s) you'll use for training, by 
 ***
 ###### ‎  
 #### 7. Select pitch extraction algorithm.
-a. At the right select the <u>[**Pitch extraction algorithm**](https://docs.aihub.wtf/rvc/resources/inference-settings/#pitch-extraction-algorithm)</u>.       
+a. At the right select the <u>[**Pitch extraction algorithm**](https://docs.ai-hub.wtf/rvc/resources/inference-settings/#pitch-extraction-algorithm)</u>.       
 Only use ``RMVPE``, ``Crepe`` or `Mangio-Crepe`, as the rest are obsolete.            
 
     <img src="../mangio-img/10.png" alt="image" width="270" height="auto"> 
@@ -225,7 +225,7 @@ b. Now click the `Feature extraction` button on the right.
 ###### ‎  
 #### 8. Create .INDEX file.
 Now click the `Train feature index` button on the bottom.         
-This will create the <u>[.INDEX</u>](https://docs.aihub.wtf/essentials/voice-models/#voice-model-files) file.       
+This will create the <u>[.INDEX</u>](https://docs.ai-hub.wtf/essentials/voice-models/#voice-model-files) file.       
 
 <img src="../mangio-img/11.png" alt="image" width="280" height="auto"> 
 
@@ -242,7 +242,7 @@ It'll finish when the output box says `Successful index Construction`.
 :::
 ###### ‎         
 #### 9. Select save frequency.
-Frequency of the <u>[saving checkpoints](https://docs.aihub.wtf/extra/glossary/#checkpoints)</u>, based on the <u>[epochs](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/)</u>.       
+Frequency of the <u>[saving checkpoints](https://docs.ai-hub.wtf/extra/glossary/#checkpoints)</u>, based on the <u>[epochs](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/)</u>.       
 
 If you are a newbie, simply leave it at `15`.    
     
@@ -254,9 +254,9 @@ E.g: with a value of ``10``, they will be saved after the epoch 10, 20, 30, etc.
 ***
 ###### ‎  
 #### 10. Input epochs amount.
-In `Total training epochs` you determine the total amount of <u>[epochs](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/)</u> (training cycles) for the model.     
+In `Total training epochs` you determine the total amount of <u>[epochs](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/)</u> (training cycles) for the model.     
 
-But since we'll use <u>[TensorBoard](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u>, use an arbitrarily large value like `2000`.
+But since we'll use <u>[TensorBoard](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u>, use an arbitrarily large value like `2000`.
 
 
 <img src="../mangio-img/13.png" alt="image" width="250" height="auto">
@@ -276,7 +276,7 @@ If your dataset is short (around 2 minutes or less), use ``4`` instead.
 #### 12. Launch TensorBoard.
 Now before you start training, open TB.     
 
-If you haven't already, start reading about it here <u><u>[here</u>](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u>.
+If you haven't already, start reading about it here <u><u>[here</u>](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/#tensorboard)</u>.
 ***
 ###### ‎  
 #### 13. Begin training.
@@ -322,7 +322,7 @@ c. Now go to the ``weights`` folder. Here you'll find the model's checkpoints.
     ‎      
 
     And that's all. Have fun with your model.   
-    To test the model, do a normal <u>[inference</u>](https://docs.aihub.wtf/essentials/how-to-make-ai-cover/) as usual.
+    To test the model, do a normal <u>[inference</u>](https://docs.ai-hub.wtf/essentials/how-to-make-ai-cover/) as usual.
 ***
 ###### ‎   
 :::content-center
@@ -357,13 +357,13 @@ If the training finished but the model still needed training, you don't have to 
 
 ==- *The voice glitches out.*
 ###### ‎   
-- This a phenomenon called artifacting. To fix it, read <u>[here](https://docs.aihub.wtf/rvc/resources/artifacting/)</u>.
+- This a phenomenon called artifacting. To fix it, read <u>[here](https://docs.ai-hub.wtf/rvc/resources/artifacting/)</u>.
 
 ===
 
 ==- *I couldn't find my answer.*
 ###### ‎   
-- Report your issue <u>[here](https://docs.aihub.wtf/rvc/#contributions)</u>.
+- Report your issue <u>[here](https://docs.ai-hub.wtf/rvc/#contributions)</u>.
 ===
 
 ***
@@ -371,5 +371,5 @@ If the training finished but the model still needed training, you don't have to 
 :::content-center
 #### `You have reached the end.`
 
-[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.aihub.wtf/rvc/#contributions)
+[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.ai-hub.wtf/rvc/#contributions)
 :::

--- a/assets/RVC/Resources/Artifacting.md
+++ b/assets/RVC/Resources/Artifacting.md
@@ -9,7 +9,7 @@ order: 2000
 ###### ‎ 
 ### Introduction        
 In RVC, artifacting refers to an anomaly where the output voice sounds "robotic" & glitchy.     
-This occurs after the <u>[inference](https://docs.aihub.wtf/extra/glossary/#inference)</u> or model training process.     
+This occurs after the <u>[inference](https://docs.ai-hub.wtf/extra/glossary/#inference)</u> or model training process.     
 ***
 ###### ‎ 
 ### Causes    
@@ -28,24 +28,24 @@ Remember that the cleaner your input audio is, the better the results.
 ###### ‎ 
 ### Solutions    
 #### 1. Use a lossless format:
-- If possible, it's best if your audio is in a <u>[lossless format](https://docs.aihub.wtf/extra/glossary/#lossless-formats)</u> like **WAV** or **FLAC**, preserving its original quality.
+- If possible, it's best if your audio is in a <u>[lossless format](https://docs.ai-hub.wtf/extra/glossary/#lossless-formats)</u> like **WAV** or **FLAC**, preserving its original quality.
 
 - Avoid using lossy ones like MP3 or OGG.
 ‎   
 #### 2. If doing inference:
-- Remove undesired noises with an <u>[vocal isolation</u>](https://docs.aihub.wtf/rvc/resources/vocal-isolation/) software.
+- Remove undesired noises with an <u>[vocal isolation</u>](https://docs.ai-hub.wtf/rvc/resources/vocal-isolation/) software.
 
-- Lowering the <u>[search feature ratio</u>](https://docs.aihub.wtf/rvc/resources/inference-settings/) can also minimize this issue.
+- Lowering the <u>[search feature ratio</u>](https://docs.ai-hub.wtf/rvc/resources/inference-settings/) can also minimize this issue.
 
-- If breathing sounds produce it, lower the <u>[Protection](https://docs.aihub.wtf/rvc/resources/inference-settings/)</u> value.
+- If breathing sounds produce it, lower the <u>[Protection](https://docs.ai-hub.wtf/rvc/resources/inference-settings/)</u> value.
 ‎   
 #### 3. If training models:
-- Ensure to <u>[clean your dataset](https://docs.aihub.wtf/rvc/resources/datasets/#cleaning-datasets)</u> properly, this includes removing silences and distortions.
+- Ensure to <u>[clean your dataset](https://docs.ai-hub.wtf/rvc/resources/datasets/#cleaning-datasets)</u> properly, this includes removing silences and distortions.
 
 ***
 ###### ‎
 :::content-center
 #### `You have reached the end.`
 
-[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.aihub.wtf/rvc/#contributions)
+[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.ai-hub.wtf/rvc/#contributions)
 :::

--- a/assets/RVC/Resources/Datasets.md
+++ b/assets/RVC/Resources/Datasets.md
@@ -38,7 +38,7 @@ order: 4000
 - Ensure there isn't background noise, reverb, overlapping voices, music, distortion, or small silences. You'll learn more in the **Cleaning** section below.   
 ‎   
 #### :icon-chevron-down: Audio quality.
-- The higher the audio quality, the better. If possible have it in a <u>[lossless](https://docs.aihub.wtf/extra/glossary/#lossless-formats)</u> format like **WAV** or **FLAC**, not a lossy one like MP3.   
+- The higher the audio quality, the better. If possible have it in a <u>[lossless](https://docs.ai-hub.wtf/extra/glossary/#lossless-formats)</u> format like **WAV** or **FLAC**, not a lossy one like MP3.   
 ‎   
 #### :icon-chevron-down: No sibilance/popping.
 - Additionally, don't include harsh sibilance (loud "S" & "SH" pronunciation) or popping sounds (loud "P" sound).   
@@ -48,9 +48,9 @@ order: 4000
 :::content-center
 ## Cleaning
 :::
-1. First, clean the undesired noises explained before using a <u>[vocal isolation](https://docs.aihub.wtf/rvc/resources/vocal-isolation/)</u> software.     
+1. First, clean the undesired noises explained before using a <u>[vocal isolation](https://docs.ai-hub.wtf/rvc/resources/vocal-isolation/)</u> software.     
 ***   
-2. Then, to remove silences, distortion & minimize (even more) noise, we'll use tools from <u>[Audacity</u>](https://www.audacityteam.org/download/). A free, simple & very light-weighted <u>[DAW](https://docs.aihub.wtf/extra/glossary/#daw)</u>.            
+2. Then, to remove silences, distortion & minimize (even more) noise, we'll use tools from <u>[Audacity</u>](https://www.audacityteam.org/download/). A free, simple & very light-weighted <u>[DAW](https://docs.ai-hub.wtf/extra/glossary/#daw)</u>.            
     ‎     
 
     {.list-icon}  
@@ -162,5 +162,5 @@ order: 4000
 :::content-center
 #### `You have reached the end.`
 
-[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.aihub.wtf/rvc/#contributions)
+[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.ai-hub.wtf/rvc/#contributions)
 :::

--- a/assets/RVC/Resources/Epochs & TensorBoard.md
+++ b/assets/RVC/Resources/Epochs & TensorBoard.md
@@ -11,7 +11,7 @@ order: 6000
 :::     
 - "Epoch" is a unit of measuring the training cycles of an AI model.     
 
-- In other words, the amount of times the model went over its <u>[dataset](https://docs.aihub.wtf/rvc/resources/datasets/)</u> and learned from it.         
+- In other words, the amount of times the model went over its <u>[dataset](https://docs.ai-hub.wtf/rvc/resources/datasets/)</u> and learned from it.         
 ###### ‎ 
 #### *:icon-chevron-right: How many epochs should I use for my dataset?*
 - There isn't a way to know the right amount previous to training. It depends on the size, length & quality of the dataset.
@@ -28,7 +28,7 @@ order: 6000
 ## Overtraining
 :::
 ###### ‎       
-- In the field of AI, is when an AI model learns its <u>[dataset](https://docs.aihub.wtf/rvc/resources/datasets/)</u> too well, to the point where it centers too much around it & starts replicating undesired data.
+- In the field of AI, is when an AI model learns its <u>[dataset](https://docs.ai-hub.wtf/rvc/resources/datasets/)</u> too well, to the point where it centers too much around it & starts replicating undesired data.
 
 - The model performs very well with data of the dataset, but poorly with new data, as it has lost its ability to replicate anything that deviates from it.
 
@@ -43,7 +43,7 @@ order: 6000
 ###### ‎
 - TensorBoard is a tool that allows you to visualize & measure the training of an AI model, through graphs & metrics.
 
-- It's specially useful for determining when to stop training a voice model, since with it you can detect when the <u><u>[overtraining</u>](https://docs.aihub.wtf/rvc/resources/epochs--tensorboard/#overtraining)</u> point begins.    
+- It's specially useful for determining when to stop training a voice model, since with it you can detect when the <u><u>[overtraining</u>](https://docs.ai-hub.wtf/rvc/resources/epochs--tensorboard/#overtraining)</u> point begins.    
 
 - Because of this, TB is the most convenient tool for RVC users for perfecting a voice model.     
 ***
@@ -51,7 +51,7 @@ order: 6000
 ### :icon-chevron-down: Installing & Opening
 
 !!!success
-For <u>[RVC Disconnected</u>](https://docs.aihub.wtf/rvc/cloud/rvc-disconnected/) users, ignore this, it opens up by itself when you start training.
+For <u>[RVC Disconnected</u>](https://docs.ai-hub.wtf/rvc/cloud/rvc-disconnected/) users, ignore this, it opens up by itself when you start training.
 !!!
 
 ###### ‎       
@@ -155,5 +155,5 @@ For <u>[RVC Disconnected</u>](https://docs.aihub.wtf/rvc/cloud/rvc-disconnected/
 :::content-center
 #### `You have reached the end.`
 
-[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.aihub.wtf/rvc/#contributions)
+[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.ai-hub.wtf/rvc/#contributions)
 :::

--- a/assets/RVC/Resources/Inference Settings.md
+++ b/assets/RVC/Resources/Inference Settings.md
@@ -10,7 +10,7 @@ order: 1000
 :::content-center
 ## Introduction
 :::
-- When doing [<u>inference</u>](https://docs.aihub.wtf/extra/glossary/#inference)</u> in RVC, you'll come across to quite a few options that you can tweak, that influence the conversion process.
+- When doing [<u>inference</u>](https://docs.ai-hub.wtf/extra/glossary/#inference)</u> in RVC, you'll come across to quite a few options that you can tweak, that influence the conversion process.
 
 - Configuring them accordingly can improve the output quality by a lot, as well as reduce artifacting, so we highly recommend learning them.   
 
@@ -45,13 +45,13 @@ order: 1000
 :::
 ‎    
 
-#### :icon-chevron-down: Also known as <u>Index Rate</u>, it determines the level of influence of model's [<u>.INDEX</u>](https://docs.aihub.wtf/essentials/voice-models/#voice-model-files) file:
+#### :icon-chevron-down: Also known as <u>Index Rate</u>, it determines the level of influence of model's [<u>.INDEX</u>](https://docs.ai-hub.wtf/essentials/voice-models/#voice-model-files) file:
 
 - Higher values will apply more of the .INDEX's characteristics.   
 
-- Lowering it can **reduce [<u>artifacting</u>](https://docs.aihub.wtf/rvc/resources/datasets/)**.      
+- Lowering it can **reduce [<u>artifacting</u>](https://docs.ai-hub.wtf/rvc/resources/datasets/)**.      
      
->Remember, if the <u>[dataset](https://docs.aihub.wtf/rvc/resources/datasets/)</u> had other sounds like background noise, there will be noise in the .INDEX too.
+>Remember, if the <u>[dataset](https://docs.ai-hub.wtf/rvc/resources/datasets/)</u> had other sounds like background noise, there will be noise in the .INDEX too.
 
 ***
 ###### ‎
@@ -74,7 +74,7 @@ order: 1000
     - Usually sounds a little harsh   
     - Should be your **go-to** algorithm, due to its convenience       
     ***
-    Some <u>[forks](https://docs.aihub.wtf/essentials/whats-rvc/#forks)</u> include **RMVPE_GPU** & **RMVPE+**. Same algorithm, but with a modification:         
+    Some <u>[forks](https://docs.ai-hub.wtf/essentials/whats-rvc/#forks)</u> include **RMVPE_GPU** & **RMVPE+**. Same algorithm, but with a modification:         
 
     <u>**RMVPE GPU**</u>:
     :   Training only. Uses more GPU power, making you train faster.
@@ -88,7 +88,7 @@ order: 1000
     ###### ‎    
     - Slower
     - Has higher quality
-    - More prone to noise & <u>[artifacting</u>](https://docs.aihub.wtf/rvc/resources/artifacting/). Switch to RMVPE if you can't fix it
+    - More prone to noise & <u>[artifacting</u>](https://docs.ai-hub.wtf/rvc/resources/artifacting/). Switch to RMVPE if you can't fix it
     - Only use it with high quality datasets/samples
     - Recommended for more **realistic** results
     ===
@@ -132,7 +132,7 @@ order: 1000
 #### :icon-chevron-down: Also known as <u>Remix Mix Rate</u>, controls the loudness of the output:
 - The closer to ``0``, the more the output will **match** the **loudness** of the **input** audio.
 
-- The closer to ``1``, the more it will match the loudness of the [<u>dataset</u>](https://docs.aihub.wtf/rvc/resources/datasets/) the **model** was trained on.
+- The closer to ``1``, the more it will match the loudness of the [<u>dataset</u>](https://docs.ai-hub.wtf/rvc/resources/datasets/) the **model** was trained on.
 
 >Basically, leave it at 0 if you want the audio to try to keep its original volume.
 ***
@@ -155,5 +155,5 @@ order: 1000
 :::content-center
 #### `You have reached the end.`
 
-[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.aihub.wtf/rvc/#contributions)
+[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.ai-hub.wtf/rvc/#contributions)
 :::

--- a/assets/RVC/Resources/Vocal Isolation.md
+++ b/assets/RVC/Resources/Vocal Isolation.md
@@ -16,7 +16,7 @@ order: 5000
 
 - The goal is to get an audio sample with clean vocals, which is what RVC needs to give the most accurate & quality results.
 
-- For RVC users, the best app is Ultimate Vocal Remover 5 (or **UVR**). It can be used either <u>[locally](https://docs.aihub.wtf/extra/glossary/#local-running)</u> or through the <u>[cloud](https://docs.aihub.wtf/rvc/resources/vocal-isolation/#cloud-uvr-)</u>. 
+- For RVC users, the best app is Ultimate Vocal Remover 5 (or **UVR**). It can be used either <u>[locally](https://docs.ai-hub.wtf/extra/glossary/#local-running)</u> or through the <u>[cloud](https://docs.ai-hub.wtf/rvc/resources/vocal-isolation/#cloud-uvr-)</u>. 
 ***
 <img src="../uvrmvsep-img/3.jpg" alt="image" width="" height="auto">‎       
 
@@ -24,7 +24,7 @@ order: 5000
 :::content-center
 ## Local UVR
 !!!warning 
-*You'll require great specs & GPU to run it effectively. Otherwise, use the <u>[cloud version](https://docs.aihub.wtf/rvc/resources/vocal-isolation/#cloud-uvr)</u>.*
+*You'll require great specs & GPU to run it effectively. Otherwise, use the <u>[cloud version](https://docs.ai-hub.wtf/rvc/resources/vocal-isolation/#cloud-uvr)</u>.*
 !!!
 :::
 ‎ 
@@ -63,16 +63,16 @@ Make sure to tick `🗹 Create a desktop shortcut` for an easier access to UVR.
     <img src="../uvrmvsep-img/4.jpg" alt="image" width="300" height="auto">         ‎    
 
 !!!success 
-For better results, have the audio in a <u>[lossless format](https://docs.aihub.wtf/extra/glossary/#lossless-formats)</u> (**WAV** or **FLAC**), & not MP3.
+For better results, have the audio in a <u>[lossless format](https://docs.ai-hub.wtf/extra/glossary/#lossless-formats)</u> (**WAV** or **FLAC**), & not MP3.
 !!!
 ***
 ‎ 
 #### 2. Select FLAC & GPU Conversion.
 ###### ‎  
 a. At the right you can select the output format.       
-We recommend picking `FLAC`. Learn why <u>[here](https://docs.aihub.wtf/extra/glossary/#lossless-formats)</u>.   
+We recommend picking `FLAC`. Learn why <u>[here](https://docs.ai-hub.wtf/extra/glossary/#lossless-formats)</u>.   
 ‎  
-b. If your GPU is **compatible with <u>[CUDA](https://docs.aihub.wtf/extra/glossary/#cuda)</u>**, toggle `GPU Conversion` on for a faster process.    
+b. If your GPU is **compatible with <u>[CUDA](https://docs.ai-hub.wtf/extra/glossary/#cuda)</u>**, toggle `GPU Conversion` on for a faster process.    
 
     <img src="../uvrmvsep-img/16.png" alt="image" width="350" height="auto">‎      
 
@@ -114,16 +114,16 @@ b. Now click the long `Start Processing` button.
     <img src="../uvrmvsep-img/4.jpg" alt="image" width="300" height="auto">         ‎    
 
 !!!success 
-For better results, have the audio in a [lossless format](https://docs.aihub.wtf/extra/glossary/#lossless-formats)</u> (**WAV** or **FLAC**), & not MP3.
+For better results, have the audio in a [lossless format](https://docs.ai-hub.wtf/extra/glossary/#lossless-formats)</u> (**WAV** or **FLAC**), & not MP3.
 !!!
 ***
 ‎   
 #### 2. Select FLAC & GPU Conversion.
 ###### ‎      
 a. At the right you can select the output format.       
-We recommend picking `FLAC`. Learn why <u>[here](https://docs.aihub.wtf/extra/glossary/#lossless-formats)</u>.     
+We recommend picking `FLAC`. Learn why <u>[here](https://docs.ai-hub.wtf/extra/glossary/#lossless-formats)</u>.     
 ‎   
-b. If your GPU is **compatible with <u>[CUDA](https://docs.aihub.wtf/extra/glossary/#cuda)</u>**, toggle `GPU Conversion` on for a faster process.    
+b. If your GPU is **compatible with <u>[CUDA](https://docs.ai-hub.wtf/extra/glossary/#cuda)</u>**, toggle `GPU Conversion` on for a faster process.    
     ‎       
         <img src="../uvrmvsep-img/16.png" alt="image" width="350" height="auto">‎      
 ###### ‎       
@@ -137,7 +137,7 @@ a. In **Process Method** select `VR`.
 b. Set **Window Size** to ``320``. (optional)        
 Lower Window Size yield a higher output **quality**, but will take **longer** to process.   
 ‎   
-b. Check the <u>[model list](https://docs.aihub.wtf/rvc/resources/vocal-isolation/#best-models)</u>. In **Select VR Model** pick the one according to what you need to remove.         
+b. Check the <u>[model list](https://docs.ai-hub.wtf/rvc/resources/vocal-isolation/#best-models)</u>. In **Select VR Model** pick the one according to what you need to remove.         
 ‎       
 If you need to remove multiple noises, follow this pipeline for the best results:   
 ``Remove instrumental -> Remove reverb -> Extract main vocals -> Remove noise``  
@@ -187,12 +187,12 @@ Click the `Start processing` button at the bottom. And that will be all.
 
 ==- *I can't remove some of the backing vocals.*
 ###### ‎
-- Run the audio through MDX23C or DeNoise. Modify the <u>[Aggression Setting](https://docs.aihub.wtf/rvc/resources/vocal-isolation/#uvr-extracted-too-little-too-much)</u> if necessary.
+- Run the audio through MDX23C or DeNoise. Modify the <u>[Aggression Setting](https://docs.ai-hub.wtf/rvc/resources/vocal-isolation/#uvr-extracted-too-little-too-much)</u> if necessary.
 ===
 
 ==- *I couldn't find my answer.*
 ###### ‎   
-- Report your issue <u>[here](https://docs.aihub.wtf/rvc/#contributions)</u>.
+- Report your issue <u>[here](https://docs.ai-hub.wtf/rvc/#contributions)</u>.
 ===
 
 ***
@@ -211,7 +211,7 @@ Click the `Start processing` button at the bottom. And that will be all.
 ###### ‎       
 #### 1. Set up Colab
 ###### ‎ 
-a. First access the Colab space <u>[here](https://colab.research.google.com/github/Eddycrack864/Music-Source-Separation-Universal-Colab/blob/main/Music_Source_Separation_Universal_Colab.ipynb)</u>. This Colab only uses **WAV** audios. If yours isn't, convert it to WAV or use <u>[MVSEP](https://docs.aihub.wtf/rvc/resources/vocal-isolation/#mvsep)</u>.     
+a. First access the Colab space <u>[here](https://colab.research.google.com/github/Eddycrack864/Music-Source-Separation-Universal-Colab/blob/main/Music_Source_Separation_Universal_Colab.ipynb)</u>. This Colab only uses **WAV** audios. If yours isn't, convert it to WAV or use <u>[MVSEP](https://docs.ai-hub.wtf/rvc/resources/vocal-isolation/#mvsep)</u>.     
 ‎       
 b. Then **Log in** to your Google account.      
 ‎   
@@ -309,7 +309,7 @@ Lower Window Size yield a higher output **quality**, but will take **longer** to
 ‎ 
 #### 4. Select model
 ###### ‎  
-d. Check the <u>[model list](https://docs.aihub.wtf/rvc/resources/vocal-isolation/#best-models)</u> & in **CHOOSE VR MODEL** pick the one according to what you need to remove.    
+d. Check the <u>[model list](https://docs.ai-hub.wtf/rvc/resources/vocal-isolation/#best-models)</u> & in **CHOOSE VR MODEL** pick the one according to what you need to remove.    
 ‎       
 If you need to remove multiple noises, follow this pipeline for the best results:   
 ``Remove instrumental -> Remove reverb -> Extract main vocals -> Remove noise``  
@@ -358,12 +358,12 @@ b. Playable audios will then appear in the output boxes below. To download the o
 
 ==- *Cannot connect to GPU backend.*
 ###### ‎   
-- You have exhausted the <u>[GPU runtime](https://docs.aihub.wtf/rvc/extra/glossary/#google-colab)</u> of Colab.
+- You have exhausted the <u>[GPU runtime](https://docs.ai-hub.wtf/rvc/extra/glossary/#google-colab)</u> of Colab.
 ===
 
 ==- *I couldn't find my answer.*
 ###### ‎   
-- Report your issue <u>[here](https://docs.aihub.wtf/rvc/#contributions)</u>.
+- Report your issue <u>[here](https://docs.ai-hub.wtf/rvc/#contributions)</u>.
 ===
 
 ***
@@ -385,7 +385,7 @@ b. Playable audios will then appear in the output boxes below. To download the o
 ***
 - MVSEP is a website for isolating vocals, that works similarly as UVR.
 
-- The <u>[UVR Colab](https://docs.aihub.wtf/rvc/resources/vocal-isolation/#cloud-uvr)</u> is much faster & convenient for this task. Use MVSEP if you run out of GPU runtime or feel lazy to convert your audio to WAV.
+- The <u>[UVR Colab](https://docs.ai-hub.wtf/rvc/resources/vocal-isolation/#cloud-uvr)</u> is much faster & convenient for this task. Use MVSEP if you run out of GPU runtime or feel lazy to convert your audio to WAV.
 
 - For free users, you can't convert audios in batches or longer than 10 minutes. If that's your case, trim it into different pieces.
 ***
@@ -420,7 +420,7 @@ a. Click `Browse File` & select your audio, or simply drag & drop. The audio wil
 a. In **Separation type** select `MDX23C`     
 ‎     
 b. In **Output encoding** select `FLAC`.          
-We recommend selecting FLAC from now on. Learn more <u>[here</u>](https://docs.aihub.wtf/extra/glossary/#lossless-formats).        
+We recommend selecting FLAC from now on. Learn more <u>[here</u>](https://docs.ai-hub.wtf/extra/glossary/#lossless-formats).        
 ‎     
 c. Once the audio is done uploading, click `Separate`       
 
@@ -471,7 +471,7 @@ a. Click `Browse File` & select your audio, or simply drag & drop. The audio wil
 ‎       
 ‎     
 b. In **Output encoding** select `FLAC`.      
-We recommend selecting FLAC from now on. Learn more <u>[here</u>](https://docs.aihub.wtf/extra/glossary/#lossless-formats).        
+We recommend selecting FLAC from now on. Learn more <u>[here</u>](https://docs.ai-hub.wtf/extra/glossary/#lossless-formats).        
 
     <img src="../uvrmvsep-img/10.png" alt="image" width="420" height="auto">‎    
 ***
@@ -480,7 +480,7 @@ We recommend selecting FLAC from now on. Learn more <u>[here</u>](https://docs.a
 ###### ‎
 a. In **Separation Type**, select `Ultimate Vocal Remover 5 HQ`.      
 ‎     
-b. Check the <u>[model list](https://docs.aihub.wtf/rvc/resources/vocal-isolation/#best-models)</u>. In `Select VR Model` pick the one according to what you need to remove.         
+b. Check the <u>[model list](https://docs.ai-hub.wtf/rvc/resources/vocal-isolation/#best-models)</u>. In `Select VR Model` pick the one according to what you need to remove.         
 ‎       
 If you need to remove multiple noises, follow this pipeline for the best results:       
 ``Remove instrumental -> Remove reverb -> Extract main vocals -> Remove noise`` 
@@ -525,7 +525,7 @@ This determines the depth of the extraction.
 
 ==- *I couldn't find my answer.*
 ###### ‎   
-- Report your issue <u>[here](https://docs.aihub.wtf/rvc/#contributions)</u>.
+- Report your issue <u>[here](https://docs.ai-hub.wtf/rvc/#contributions)</u>.
 ===
 ***       
 ###### ‎ 
@@ -558,5 +558,5 @@ Noise | Ultimate Vocal Remover 5 HQ | UVR-DeNoise
 :::content-center
 #### `You have reached the end.`
 
-[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.aihub.wtf/rvc/#contributions)
+[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.ai-hub.wtf/rvc/#contributions)
 :::

--- a/assets/TTS/GPT-SoVITS.md
+++ b/assets/TTS/GPT-SoVITS.md
@@ -59,7 +59,7 @@ order: 1000
 
 - GPT-So-VITS is made for **TTS only**, so it's also best to remove any singing/muffly voice parts.
 
-- #### <u>[Learn how to clean datasets](https://docs.aihub.wtf/rvc/resources/datasets/)</u>.
+- #### <u>[Learn how to clean datasets](https://docs.ai-hub.wtf/rvc/resources/datasets/)</u>.
 ***
 ###### ‎
 #### 2. Audio Slicer
@@ -217,5 +217,5 @@ e. Fill the **Inference text** & set the **Inference language**, then click ``St
 :::content-center
 #### `You have reached the end.`
 
-[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.aihub.wtf/rvc/#contributions)
+[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.ai-hub.wtf/rvc/#contributions)
 :::

--- a/assets/TTS/TTS Tools.md
+++ b/assets/TTS/TTS Tools.md
@@ -10,7 +10,7 @@ order: 2000
 ***
 - TTS is an abbreviation of Text To Speech, an AI that converts any given text into vocal speech.
 
-- The ones listed here offer a decent variety of features & options, such as <u>[model training](https://docs.aihub.wtf/extra/glossary/#model-training)</u>, <u>[fine-tuning](https://docs.aihub.wtf/extra/glossary/#fine-tuning)</u>, <u>[0 shot training](https://docs.aihub.wtf/extra/glossary/#0-shot-training)</u>, or being <u>[mixed with RVC](https://ominous-waffle-r44vr6g95vvj2wqrx-5000.app.github.dev/other-ai/tts-tools/#rvc-forks)</u>.
+- The ones listed here offer a decent variety of features & options, such as <u>[model training](https://docs.ai-hub.wtf/extra/glossary/#model-training)</u>, <u>[fine-tuning](https://docs.ai-hub.wtf/extra/glossary/#fine-tuning)</u>, <u>[0 shot training](https://docs.ai-hub.wtf/extra/glossary/#0-shot-training)</u>, or being <u>[mixed with RVC](https://ominous-waffle-r44vr6g95vvj2wqrx-5000.app.github.dev/other-ai/tts-tools/#rvc-forks)</u>.
 
 - Here's an index of the best TTS tools out there:    
 ‎
@@ -27,19 +27,19 @@ order: 2000
 - It’s characterized by its great ability to express **emotions** & non-speech sounds.
 - Examples are laughter, laughs, sighs, gasps, clearing throat, hesitations ( - or … ), emphasis of words, etc.
 
-- It can be used both <u>[locally](https://docs.aihub.wtf/extra/glossary/#local-running)</u> or in the <u>[cloud](https://docs.aihub.wtf/rvc/extra/glossary/#cloud-based)</u>:
+- It can be used both <u>[locally](https://docs.ai-hub.wtf/extra/glossary/#local-running)</u> or in the <u>[cloud](https://docs.ai-hub.wtf/rvc/extra/glossary/#cloud-based)</u>:
 
   +++ :icon-device-desktop: ‎ LOCAL
   
   {.list-icon}
   - :icon-book: [Official Guide](https://github.com/suno-ai/bark)
-  - :icon-repo-forked: [Fixed Fork](https://github.com/Nick088Official/bark-gui-fix) (with UI & [fine-tuning](https://docs.aihub.wtf/extra/glossary/#fine-tuning))
+  - :icon-repo-forked: [Fixed Fork](https://github.com/Nick088Official/bark-gui-fix) (with UI & [fine-tuning](https://docs.ai-hub.wtf/extra/glossary/#fine-tuning))
   - :icon-rocket: [Voice Cloning](https://github.com/KevinWang676/Bark-Voice-Cloning/tree/main)
 
   +++ :icon-cloud: ‎ CLOUD
 
   - [Bark TTS Colab](https://colab.research.google.com/github/Nick088Official/Easier-Bark-TTS-Google-Colab/blob/main/Easier_Bark_TTS.ipynb)
-  - [GUI Version](https://colab.research.google.com/github/Nick088Official/bark-gui-fix-google-colab/blob/main/Bark_GUI_Fix.ipynb) (with [fine-tuning](https://docs.aihub.wtf/extra/glossary/#fine-tuning))
+  - [GUI Version](https://colab.research.google.com/github/Nick088Official/bark-gui-fix-google-colab/blob/main/Bark_GUI_Fix.ipynb) (with [fine-tuning](https://docs.ai-hub.wtf/extra/glossary/#fine-tuning))
   - [0 Shot Voice Cloning](https://colab.research.google.com/github/Nick088Official/Easier-Bark-Voice-Cloning-Google-Colab/blob/main/Bark_Voice_Cloning.ipynb)
   - [Official HF Space](https://huggingface.co/spaces/suno/bark)
   - [0 Shot Voice Cloning HF Space](https://huggingface.co/spaces/kevinwang676/Bark-with-Voice-Cloning)
@@ -51,7 +51,7 @@ order: 2000
 ***
 - This is Microsoft Edge TTS, which is good **quality**, multilingual & works great on long sentences. 
 
-- It can only be used online via their API, through their web browser, a HF/Colab space or **mixed with <u>[RVC](https://docs.aihub.wtf/rvc/essentials/whats-rvc/)</u>**.
+- It can only be used online via their API, through their web browser, a HF/Colab space or **mixed with <u>[RVC](https://docs.ai-hub.wtf/rvc/essentials/whats-rvc/)</u>**.
 
   +++ :icon-globe: ‎ BROWSER
   1. [Download the browser.](https://www.microsoft.com/en-us/edge/download?ch=1&form=MA13FJ)
@@ -102,9 +102,9 @@ order: 2000
   - 🤗 [Hugging Face](https://huggingface.co/spaces/Nick088/Edge-TTS)
 
   +++ :icon-dependabot: RVC FORKS
-  - [Ilaria RVC](https://docs.aihub.wtf/rvc/cloud/ilaria-rvc/#tts-) 
-  - [Applio Colab](https://docs.aihub.wtf/rvc/cloud/applio-colab/#tts)
-  - [Local Applio](https://docs.aihub.wtf/rvc/local/applio/)   
+  - [Ilaria RVC](https://docs.ai-hub.wtf/rvc/cloud/ilaria-rvc/#tts-) 
+  - [Applio Colab](https://docs.ai-hub.wtf/rvc/cloud/applio-colab/#tts)
+  - [Local Applio](https://docs.ai-hub.wtf/rvc/local/applio/)   
   ‎
   !!!
   These being mixed with RVC means it generates the speech & runs the output through RVC, applying the voice model.
@@ -115,7 +115,7 @@ order: 2000
 ***
 - StyleTTS 2 aims to achieve human-level TTS synthesis only in English.   
 ‎   
-- It works better on full sentences, is both available locally & online, and you can [fine-tune](https://docs.aihub.wtf/extra/glossary/#fine-tuning) it with your own dataset.    
+- It works better on full sentences, is both available locally & online, and you can [fine-tune](https://docs.ai-hub.wtf/extra/glossary/#fine-tuning) it with your own dataset.    
 ‎   
 - It has 2 versions:   
 ‎       
@@ -264,5 +264,5 @@ order: 2000
 :::content-center
 #### `You have reached the end.`
 
-[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.aihub.wtf/rvc/#contributions)
+[!badge variant="info" size="xl" corners="pill" icon="paper-airplane" iconAlign="right" text="Report Issues"](https://docs.ai-hub.wtf/rvc/#contributions)
 :::

--- a/assets/welcome.md
+++ b/assets/welcome.md
@@ -12,7 +12,7 @@ icon: home-fill
 #### **``AI and RVC-related guides.``**
 :::
 :::content-center
-##### <u>[LEARN MORE](https://docs.aihub.wtf/#introduction)</u>
+##### <u>[LEARN MORE](https://docs.ai-hub.wtf/#introduction)</u>
 :::
 
 ***
@@ -22,21 +22,21 @@ icon: home-fill
 #### - Starting point for beginners -      
 :::
 ###### ‎
-#### :icon-chevron-right: 🎵 <u>[How to Make AI Cover](https://docs.aihub.wtf/essentials/how-to-make-ai-cover/)</u>
+#### :icon-chevron-right: 🎵 <u>[How to Make AI Cover](https://docs.ai-hub.wtf/essentials/how-to-make-ai-cover/)</u>
 ***
-#### :icon-chevron-right: :icon-rocket: ‎ <u>[How to Make Voice Models](https://docs.aihub.wtf/essentials/how-to-make-voice-models/)</u>
+#### :icon-chevron-right: :icon-rocket: ‎ <u>[How to Make Voice Models](https://docs.ai-hub.wtf/essentials/how-to-make-voice-models/)</u>
 ***
-#### :icon-chevron-right: 💾 <u>[Voice Models](https://docs.aihub.wtf/essentials/voice-models/)</u>
+#### :icon-chevron-right: 💾 <u>[Voice Models](https://docs.ai-hub.wtf/essentials/voice-models/)</u>
 ***
-#### :icon-chevron-right: :icon-info: ‎ [<u>What's RVC](https://docs.aihub.wtf/essentials/whats-rvc/)</u>
+#### :icon-chevron-right: :icon-info: ‎ [<u>What's RVC](https://docs.ai-hub.wtf/essentials/whats-rvc/)</u>
 ***
-#### :icon-chevron-right: 🍏 [<u>Applio Guide](https://docs.aihub.wtf/rvc/local/applio/)</u> - New!
+#### :icon-chevron-right: 🍏 [<u>Applio Guide](https://docs.ai-hub.wtf/rvc/local/applio/)</u> - New!
 
 !!!
 ***
 ###### ‎    
 ## Introduction :icon-book:
-- This site is a documentation of AI tools, mostly <u>[RVC](https://docs.aihub.wtf/essentials/whats-rvc/)</u>-related apps. Made by members of [<u>**AI HUB**</u>](https://discord.com/invite/aihub).
+- This site is a documentation of AI tools, mostly <u>[RVC](https://docs.ai-hub.wtf/essentials/whats-rvc/)</u>-related apps. Made by members of [<u>**AI HUB**</u>](https://discord.com/invite/aihub).
 
 - See **simple & convenient guides** regarding model training, inference, audio isolation, datasets, TensorBoard, & more. Verified by the experts & for **all** devices.      
 ***

--- a/retype.yml
+++ b/retype.yml
@@ -1,7 +1,7 @@
 input: ./assets
 output: .retype
 
-url: https://docs.aihub.wtf/
+url: https://docs.ai-hub.wtf/
 
 branding:
   title:
@@ -14,7 +14,7 @@ links:
   link: https://discord.gg/aihub
   icon: question
 - text: Report Issues
-  link: https://docs.aihub.wtf/#contributions
+  link: https://docs.ai-hub.wtf/#contributions
   icon: stop
 - text: GitHub
   link: https://github.com/AIHubCentral/docs


### PR DESCRIPTION
As the main docs are down, the hyperlinks don’t work, so i changed the hyperlinks from the main docs to the temporary docs for now (so from docs.aihub.wtf to docs.ai-hub.wtf)